### PR TITLE
Disable linting to fix build

### DIFF
--- a/src/sota_tools/rate_controller.cc
+++ b/src/sota_tools/rate_controller.cc
@@ -48,6 +48,8 @@ bool RateController::ServerHasFailed() const {
   return sleep_time_ > kMaxSleepTime;
 }
 
+// These assert()'s are compiled out in Release builds, which triggers a clang-tidy warning
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void RateController::CheckInvariants() const {
   assert((sleep_time_ == clock::duration(0)) || (max_concurrency_ == 1));
   assert(0 < max_concurrency_);


### PR DESCRIPTION
"ninja qa" was failing for Release builds because the assert() calls get
compiled out in release and clang-tidy couldn't see a reason why this needed to
be a member function. Disable the lint rule for this line.

Signed-off-by: Phil Wise <phil@phil-wise.com>