### PR TITLE
Bump 'expires' in test code to the future

### DIFF
--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -1588,7 +1588,7 @@ TEST(Aktualizr, TargetAutoremove) {
   Utils::createDirectories(local_metadir, S_IRWXU);
   auto http = std::make_shared<HttpFake>(temp_dir.Path(), "", local_metadir / "repo");
 
-  UptaneRepo repo{local_metadir, "2021-07-04T16:33:27Z", "id0"};
+  UptaneRepo repo{local_metadir, "2025-07-04T16:33:27Z", "id0"};
   repo.generateRepo(KeyType::kED25519);
   const std::string hwid = "primary_hw";
   repo.addImage(fake_meta_dir / "fake_meta/primary_firmware.txt", "primary_firmware.txt", hwid, "", {});

--- a/src/uptane_generator/repo_test.cc
+++ b/src/uptane_generator/repo_test.cc
@@ -343,7 +343,7 @@ TEST(uptane_generator, sign) {
   cmd = generate_repo_exec + " sign " + temp_dir.Path().string();
   cmd += " --repotype director --keyname snapshot";
   std::string sign_cmd =
-      "echo \"{\\\"_type\\\":\\\"Snapshot\\\",\\\"expires\\\":\\\"2021-07-04T16:33:27Z\\\"}\" | " + cmd;
+      "echo \"{\\\"_type\\\":\\\"Snapshot\\\",\\\"expires\\\":\\\"2025-07-04T16:33:27Z\\\"}\" | " + cmd;
   output.clear();
   retval = Utils::shell(sign_cmd, &output);
   if (retval) {

--- a/tests/metafake.h
+++ b/tests/metafake.h
@@ -3,6 +3,7 @@
 
 #include <fstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <boost/filesystem.hpp>
@@ -13,8 +14,10 @@
 
 class MetaFake {
  public:
-  MetaFake(const boost::filesystem::path &meta_dir_in)
-      : meta_dir(meta_dir_in), work_dir(meta_dir / "fake_meta"), repo(work_dir, "2021-07-04T16:33:27Z", "id0") {
+  explicit MetaFake(boost::filesystem::path meta_dir_in)
+      : meta_dir(std::move(meta_dir_in)),
+        work_dir(meta_dir / "fake_meta"),
+        repo(work_dir, "2025-07-04T16:33:27Z", "id0") {
     repo.generateRepo(KeyType::kED25519);
     backup();
     create_image();

--- a/tests/uptane_repo_generation/delegation_basic.sh
+++ b/tests/uptane_repo_generation/delegation_basic.sh
@@ -30,7 +30,7 @@ echo "secondary" > "$SECONDARY_FIRMWARE"
 if [[ "$REVOKE" = "revoke" ]]; then
     uptane_gen --command revokedelegation --dname new-role
 else
-    uptane_gen --command generate --expires 2021-07-04T16:33:27Z
+    uptane_gen --command generate --expires 2025-07-04T16:33:27Z
     uptane_gen --command adddelegation --dname new-role --dpattern "abc/*" --keytype ed25519
     uptane_gen --command image --filename "$PRIMARY_FIRMWARE" --targetname primary.txt --hwid primary_hw
     uptane_gen --command image --filename "$SECONDARY_FIRMWARE" --targetname "abc/secondary.txt" --dname new-role --hwid secondary_hw

--- a/tests/uptane_repo_generation/delegation_nested.sh
+++ b/tests/uptane_repo_generation/delegation_nested.sh
@@ -33,7 +33,7 @@ if [[ "$REVOKE" = "revoke" ]]; then
     uptane_gen --command revokedelegation --dname role-abc
 else
     echo "NORMAL"
-    uptane_gen --command generate --expires 2021-07-04T16:33:27Z
+    uptane_gen --command generate --expires 2025-07-04T16:33:27Z
     uptane_gen --command adddelegation --dname delegation-top --dpattern "ab*"
     uptane_gen --command adddelegation --dname role-abc --dpattern "abc/*" --dparent delegation-top
     uptane_gen --command adddelegation --dname role-bcd --dpattern "bcd/*" --dparent delegation-top

--- a/tests/uptane_repo_generation/generate_repo.sh
+++ b/tests/uptane_repo_generation/generate_repo.sh
@@ -44,7 +44,7 @@ trap 'rm -rf "$IMAGES"' exit
 PRIMARY_FIRMWARE="$IMAGES/primary.txt"
 echo "primary" > "$PRIMARY_FIRMWARE"
 
-uptane_gen --command generate --expires 2021-07-04T16:33:27Z
+uptane_gen --command generate --expires 2025-07-04T16:33:27Z
 uptane_gen --command image --filename "$PRIMARY_FIRMWARE" --targetname primary.txt --hwid primary_hw
 uptane_gen --command addtarget --hwid primary_hw --serial CA:FE:A6:D2:84:9D --targetname primary.txt
 


### PR DESCRIPTION
The test code was generating a Uptane root.json that was already expired. This
caused tests to fail. Bump the expiry date by a few years.

Signed-off-by: Phil Wise <phil@phil-wise.com>