### PR TITLE
Make CommandQueue non-movable and non-copyable

### DIFF
--- a/src/libaktualizr/utilities/apiqueue.h
+++ b/src/libaktualizr/utilities/apiqueue.h
@@ -56,7 +56,13 @@ class FlowControlToken {
 
 class CommandQueue {
  public:
+  CommandQueue() = default;
   ~CommandQueue();
+  // Non-copyable Non-movable
+  CommandQueue(const CommandQueue&) = delete;
+  CommandQueue(CommandQueue&&) = delete;
+  CommandQueue& operator=(const CommandQueue&) = delete;
+  CommandQueue& operator=(CommandQueue&&) = delete;
   void run();
   bool pause(bool do_pause);  // returns true iff pause→resume or resume→pause
   void abort(bool restart_thread = true);


### PR DESCRIPTION
It really isn't safe to move or copy...

Signed-off-by: Phil Wise <phil@phil-wise.com>