### PR TITLE
Add stricter testing to reregistration tests

### DIFF
--- a/src/libaktualizr/primary/reregistration_test.cc
+++ b/src/libaktualizr/primary/reregistration_test.cc
@@ -63,6 +63,7 @@ TEST(Aktualizr, AddSecondary) {
 
   std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
   UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
+  EXPECT_EQ(http->device_registration_count, 1);
   EXPECT_EQ(http->ecu_registration_count, 1);
 
   ecu_config.ecu_serial = "ecuserial4";
@@ -70,6 +71,7 @@ TEST(Aktualizr, AddSecondary) {
   aktualizr.Initialize();
   expected_ecus.push_back(ecu_config.ecu_serial);
   UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
+  EXPECT_EQ(http->device_registration_count, 1);
   EXPECT_EQ(http->ecu_registration_count, 2);
 }
 
@@ -90,6 +92,7 @@ TEST(Aktualizr, RemoveSecondary) {
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
     UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
+    EXPECT_EQ(http->device_registration_count, 1);
     EXPECT_EQ(http->ecu_registration_count, 1);
   }
 
@@ -99,6 +102,7 @@ TEST(Aktualizr, RemoveSecondary) {
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "secondary_ecu_serial"};
     UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
+    EXPECT_EQ(http->device_registration_count, 1);
     EXPECT_EQ(http->ecu_registration_count, 2);
   }
 }
@@ -120,6 +124,7 @@ TEST(Aktualizr, ReplaceSecondary) {
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
     UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
+    EXPECT_EQ(http->device_registration_count, 1);
     EXPECT_EQ(http->ecu_registration_count, 1);
   }
 
@@ -132,6 +137,7 @@ TEST(Aktualizr, ReplaceSecondary) {
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial4", "secondary_ecu_serial"};
     UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
+    EXPECT_EQ(http->device_registration_count, 1);
     EXPECT_EQ(http->ecu_registration_count, 2);
   }
 }
@@ -150,8 +156,8 @@ TEST(Aktualizr, RestartNoRegisterSecondaries) {
     Primary::VirtualSecondaryConfig ecu_config = UptaneTestCommon::altVirtualConfiguration(temp_dir.Path());
     aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
     aktualizr.Initialize();
-    EXPECT_EQ(http->ecu_registration_count, 1);
     EXPECT_EQ(http->device_registration_count, 1);
+    EXPECT_EQ(http->ecu_registration_count, 1);
   }
 
   {
@@ -159,8 +165,8 @@ TEST(Aktualizr, RestartNoRegisterSecondaries) {
     Primary::VirtualSecondaryConfig ecu_config = UptaneTestCommon::altVirtualConfiguration(temp_dir.Path());
     aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
     aktualizr.Initialize();
-    EXPECT_EQ(http->ecu_registration_count, 1);
     EXPECT_EQ(http->device_registration_count, 1);
+    EXPECT_EQ(http->ecu_registration_count, 1);
   }
 }
 
@@ -177,16 +183,16 @@ TEST(Aktualizr, RestartNoRegisterPrimaryOnly) {
     auto storage = INvStorage::newStorage(conf.storage);
     UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
     aktualizr.Initialize();
-    EXPECT_EQ(http->ecu_registration_count, 1);
     EXPECT_EQ(http->device_registration_count, 1);
+    EXPECT_EQ(http->ecu_registration_count, 1);
   }
 
   {
     auto storage = INvStorage::newStorage(conf.storage);
     UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
     aktualizr.Initialize();
-    EXPECT_EQ(http->ecu_registration_count, 1);
     EXPECT_EQ(http->device_registration_count, 1);
+    EXPECT_EQ(http->ecu_registration_count, 1);
   }
 }
 

--- a/src/libaktualizr/primary/reregistration_test.cc
+++ b/src/libaktualizr/primary/reregistration_test.cc
@@ -18,19 +18,20 @@ class HttpFakeRegistration : public HttpFake {
 
   HttpResponse post(const std::string& url, const Json::Value& data) override {
     if (url.find("/devices") != std::string::npos) {
+      device_registration_count++;
       auto this_device_id = data["deviceId"].asString();
-      if (registration_count <= 1) {
+      if (ecu_registration_count <= 1) {
         device_id = this_device_id;
       } else {
         EXPECT_EQ(device_id, this_device_id) << "deviceId should change during provisioning";
       }
     }
     if (url.find("/director/ecus") != std::string::npos) {
-      registration_count += 1;
+      ecu_registration_count++;
       EXPECT_EQ(data["primary_ecu_serial"].asString(), "CA:FE:A6:D2:84:9D");
       EXPECT_EQ(data["ecus"][0]["ecu_serial"].asString(), "CA:FE:A6:D2:84:9D");
       EXPECT_EQ(data["ecus"][0]["hardware_identifier"].asString(), "primary_hw");
-      if (registration_count == 1) {
+      if (ecu_registration_count == 1) {
         primary_ecu_info = data["ecus"][0];
       } else {
         EXPECT_EQ(primary_ecu_info, data["ecus"][0]) << "Information about primary ECU shouldn't change";
@@ -40,7 +41,8 @@ class HttpFakeRegistration : public HttpFake {
     return HttpFake::post(url, data);
   }
 
-  unsigned int registration_count{0};
+  unsigned int ecu_registration_count{0};
+  unsigned int device_registration_count{0};
   Json::Value primary_ecu_info;
   std::string device_id;
 };
@@ -61,14 +63,14 @@ TEST(Aktualizr, AddSecondary) {
 
   std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
   UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
-  EXPECT_EQ(http->registration_count, 1);
+  EXPECT_EQ(http->ecu_registration_count, 1);
 
   ecu_config.ecu_serial = "ecuserial4";
   aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
   aktualizr.Initialize();
   expected_ecus.push_back(ecu_config.ecu_serial);
   UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
-  EXPECT_EQ(http->registration_count, 2);
+  EXPECT_EQ(http->ecu_registration_count, 2);
 }
 
 /*
@@ -88,7 +90,7 @@ TEST(Aktualizr, RemoveSecondary) {
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
     UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
-    EXPECT_EQ(http->registration_count, 1);
+    EXPECT_EQ(http->ecu_registration_count, 1);
   }
 
   {
@@ -97,7 +99,7 @@ TEST(Aktualizr, RemoveSecondary) {
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "secondary_ecu_serial"};
     UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
-    EXPECT_EQ(http->registration_count, 2);
+    EXPECT_EQ(http->ecu_registration_count, 2);
   }
 }
 
@@ -118,7 +120,7 @@ TEST(Aktualizr, ReplaceSecondary) {
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial3", "secondary_ecu_serial"};
     UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
-    EXPECT_EQ(http->registration_count, 1);
+    EXPECT_EQ(http->ecu_registration_count, 1);
   }
 
   {
@@ -130,7 +132,61 @@ TEST(Aktualizr, ReplaceSecondary) {
 
     std::vector<std::string> expected_ecus = {"CA:FE:A6:D2:84:9D", "ecuserial4", "secondary_ecu_serial"};
     UptaneTestCommon::verifyEcus(temp_dir, expected_ecus);
-    EXPECT_EQ(http->registration_count, 2);
+    EXPECT_EQ(http->ecu_registration_count, 2);
+  }
+}
+
+/**
+ * Restarting Aktualizr without changing the secondaries should not result in it getting re-registered
+ */
+TEST(Aktualizr, RestartNoRegisterSecondaries) {
+  TemporaryDirectory temp_dir;
+  auto http = std::make_shared<HttpFakeRegistration>(temp_dir.Path(), fake_meta_dir);
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  auto storage = INvStorage::newStorage(conf.storage);
+
+  {
+    UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+    Primary::VirtualSecondaryConfig ecu_config = UptaneTestCommon::altVirtualConfiguration(temp_dir.Path());
+    aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
+    aktualizr.Initialize();
+    EXPECT_EQ(http->ecu_registration_count, 1);
+    EXPECT_EQ(http->device_registration_count, 1);
+  }
+
+  {
+    UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+    Primary::VirtualSecondaryConfig ecu_config = UptaneTestCommon::altVirtualConfiguration(temp_dir.Path());
+    aktualizr.AddSecondary(std::make_shared<Primary::VirtualSecondary>(ecu_config));
+    aktualizr.Initialize();
+    EXPECT_EQ(http->ecu_registration_count, 1);
+    EXPECT_EQ(http->device_registration_count, 1);
+  }
+}
+
+/**
+ * Restarting Aktualizr should not result in it getting re-registered if it has no secondaries.
+ * This is similar to RestartNoRegisterSecondaries, but with zero secondaries.
+ */
+TEST(Aktualizr, RestartNoRegisterPrimaryOnly) {
+  TemporaryDirectory temp_dir;
+  auto http = std::make_shared<HttpFakeRegistration>(temp_dir.Path(), fake_meta_dir);
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+
+  {
+    auto storage = INvStorage::newStorage(conf.storage);
+    UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+    EXPECT_EQ(http->ecu_registration_count, 1);
+    EXPECT_EQ(http->device_registration_count, 1);
+  }
+
+  {
+    auto storage = INvStorage::newStorage(conf.storage);
+    UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+    aktualizr.Initialize();
+    EXPECT_EQ(http->ecu_registration_count, 1);
+    EXPECT_EQ(http->device_registration_count, 1);
   }
 }
 


### PR DESCRIPTION
This checks that the identity of the primary doesn't change when the device is
reregistered.

Signed-off-by: Phil Wise <phil@phil-wise.com>