### PR TITLE
Support TUF-only verification in aktualizr-secondary.

### DIFF
--- a/config/posix-secondary-config.json
+++ b/config/posix-secondary-config.json
@@ -2,6 +2,6 @@
   "IP": {
     "secondaries_wait_port": 9040,
     "secondaries_wait_timeout": 120,
-    "secondaries": [{"addr": "127.0.0.1:9050"}]
+    "secondaries": [{"addr": "127.0.0.1:9050", "verification_type": "Full"}]
   }
 }

--- a/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/posix-secondaries.adoc
@@ -24,7 +24,7 @@ A key component of this repository is libaktualizr which is a library implementi
 
 *Build*
 
-The Secondary executable is built by default, thus following build instructions outlined in link:{aktualizr-github-url}/README.adoc[the repo's README] should do the trick. If the build procedure is completed successfully then aktualizr-Secondary can be found in ``<build-dir>/src/aktualizr_secondary/aktualizr-secondary``.
+The Secondary executable is built by default, thus following build instructions outlined in link:{aktualizr-github-url}/README.adoc[the repo's README] should do the trick. If the build procedure is completed successfully then aktualizr-Secondary can be found in `<build-dir>/src/aktualizr_secondary/aktualizr-secondary`.
 
 *Configure*
 
@@ -40,36 +40,32 @@ More details on the configuration in general and specific parameters can be foun
 
 *Run*
 
-``<build-dir>/src/aktualizr_secondary/aktualizr-secondary -c <src-root>/config/posix-secondary.toml``
+`<build-dir>/src/aktualizr_secondary/aktualizr-secondary -c <src-root>/config/posix-secondary.toml`
 Once it's started, you should see a message saying that aktualizr-secondary is listening on the port specified in the config.
 
 
 == *Primary*
 
 *Build*
-The Primary executable is built by default, thus following build instructions outlined in link:{aktualizr-github-url}/README.adoc[the repo's README] should do the trick. If the build procedure is completed successfully then aktualizr executable can be found in ``<build-dir>/src/aktualizr_primary/aktualizr``.
+The Primary executable is built by default, thus following build instructions outlined in link:{aktualizr-github-url}/README.adoc[the repo's README] should do the trick. If the build procedure is completed successfully then aktualizr executable can be found in `<build-dir>/src/aktualizr_primary/aktualizr`.
 
 *Configure*
 
 A default configuration of aktualizr acting as Primary can be found in link:{aktualizr-github-url}/config/sota-local-with-secondaries.toml[<src-root>/config/sota-local-with-secondaries.toml].
 
-One configuration parameter that is worth mentioning is `[uptane]: secondary_config_file`, which specifies a path
-to a configuration file containing input parameters for aktualizr/Primary to communicate with any Secondaries.
-This is a link:{aktualizr-github-url}/config/posix-secondary-config.json[default Secondary configuration for Primary].
-In order to use the given default config file, either copy it into your current working directory or update
-`[uptane]: secondary_config_file` value so it defines a full path to the Secondary config file (e.g. ``<src-root>/config/posix-secondary-config.json``).
+Of particular importance is the configuration parameter `[uptane]: secondary_config_file`, which specifies a path to a configuration file containing input parameters for the Primary (e.g. aktualizr) to communicate with any Secondaries. See for example link:{aktualizr-github-url}/config/posix-secondary-config.json[the default Secondary configuration for the Primary]. To use this config file, either copy it to your current working directory or set the `[uptane]: secondary_config_file` value to the full path of the Secondary config file (e.g. `<src-root>/config/posix-secondary-config.json`).
 
-Configuration parameters of Secondaries for Primary/aktualizr that are worth mentioning are:
+The available configuration parameters of Secondaries for the Primary are:
 
 * `secondaries_wait_port` - TCP port aktualizr listen on for connections from Secondaries
 * `secondaries_wait_timeout` - timeout (in sec) of waiting for connections from Secondaries. Primary/aktualizr waits for a connection from those Secondaries that it failed to connect to at the startup time.
-* `secondaries` -  a list of Secondary TCP/IP addresses
+* `secondaries` -  a list of TCP/IP addresses and the associated metadata verification type of each Secondary.
 
 Put your credential.zip file into the current working directory or update `[provision] provision_path` in link:{aktualizr-github-url}/config/sota-local-with-secondaries.toml[the config] so it specifies a full path to your credential file.
 
 *Run*
 
-``<build-dir>/src/aktualizr_primary/aktualizr -c <src-root>/config/sota-local-with-secondaries.toml``
+`<build-dir>/src/aktualizr_primary/aktualizr -c <src-root>/config/sota-local-with-secondaries.toml`
 Once aktualizr is running, check the output for *_Adding Secondary to Aktualizr_* and *_Provisioned successfully on Device Gateway_*. You should then see that a new device has been registered on the server and that it includes two ECUs: your local Primary and Secondary. You can now send updates to either ECU.
 
 == *Tips and Tricks*
@@ -82,10 +78,10 @@ echo 'export AKT_PROJ_HOME="<aktualizr-source-root>"' >> ~/.profile
 ....
 echo 'export AKT_BUILD_DIR="$AKT_PROJ_HOME/build"' >> ~/.profile
 ....
-* Use ``$AKT_PROJ_HOME/config/sota-local-with-secondaries.toml`` as the config for your emulated Primary ECU
-* Copy ``$AKT_PROJ_HOME/config/posix-secondary-config.json`` to the directory you run your Primary from, let's call it `PRIMARY_HOME_DIR` further.
-* Copy your credential file ``credentials.zip`` to `PRIMARY_HOME_DIR`
-* Use ``$AKT_PROJ_HOME/config/posix-secondary.toml`` as the config for your emulated Secondary ECU
+* Use `$AKT_PROJ_HOME/config/sota-local-with-secondaries.toml` as the config for your emulated Primary ECU
+* Copy `$AKT_PROJ_HOME/config/posix-secondary-config.json` to the directory you run your Primary from (`PRIMARY_HOME_DIR`)
+* Copy your credential file `credentials.zip` to `PRIMARY_HOME_DIR`
+* Use `$AKT_PROJ_HOME/config/posix-secondary.toml` as the config for your emulated Secondary ECU
 * To run the Primary launch the following from `PRIMARY_HOME_DIR`
 ....
 $AKT_PRIMARY -c $AKT_PROJ_HOME/config/sota-local-with-secondaries.toml
@@ -95,7 +91,7 @@ $AKT_PRIMARY -c $AKT_PROJ_HOME/config/sota-local-with-secondaries.toml
 $AKT_SECNDR -c $AKT_PROJ_HOME/config/posix-secondary.toml
 ....
 * Add --loglevel 0 to the aforementioned launch commands if you would like to see more logs
-* To re-register your emulated multi-ECU device (or start playing it from scratch) remove ``storage`` directory from `PRIMARY_HOME_DIR`
+* To re-register your emulated multi-ECU device (or start playing it from scratch) remove `storage` directory from `PRIMARY_HOME_DIR`
 
 === Multiple Secondaries
 
@@ -104,13 +100,8 @@ In order to emulate a device containing one Primary ECU along with more than one
 * Run the Secondary executable `<build-dir>/src/aktualizr_secondary/aktualizr-secondary` desired number of times each from different directories.
 Prior to running Secondary executables, please,
 
- ** copy the configuration file <src-root>/config/posix-secondary.toml to each directory the Secondary will be launched from.
- Let's call such directory as `SECONDARY_HOME_DIR`;
+ ** copy the configuration file `<src-root>/config/posix-secondary.toml` to each directory the Secondary will be launched from (`SECONDARY_HOME_DIR`);
 
- ** update a value of `[network]:port` parameter of the config file in each `SECONDARY_HOME_DIR` directory in such way
-  that each Secondary config specifies different port number (9050 by default) hence each Secondary will listen on different port;
+ ** update the value of `[network]:port` parameter of the config file in each `SECONDARY_HOME_DIR` directory such that each Secondary config specifies different port number (9050 by default) and thus each Secondary will listen on different port;
 
-* Update posix-secondary-config.json located in `PRIMARY_HOME_DIR` (see instructions in p. `Primary`) with details of each Secondary
- that was executed in previous step, specifically, add corresponding values to `secondaries` list field (e.g. `"secondaries": [{"addr": "127.0.0.1:9050"}, {"addr": "127.0.0.1:9051"}]`).
- Once posix-secondary-config.json is updated run the Primary, as result you should see that it is connected with multiple Secondaries
- in aktualizr logs as well as on UI.
+* Update `posix-secondary-config.json` located in `PRIMARY_HOME_DIR` (see instructions above in the `Primary` section) with details of each Secondary that was executed in previous step. Specifically, add corresponding values to `secondaries` list field (e.g. `"secondaries": [{"addr": "127.0.0.1:9050", "verification_type": "Full"}, {"addr": "127.0.0.1:9051", "verification_type": "Full"}]`). Once `posix-secondary-config.json` is updated, run the Primary. You should see that it is connected with multiple Secondaries in the aktualizr logs as well as in the web UI.

--- a/include/libaktualizr/secondary_provider.h
+++ b/include/libaktualizr/secondary_provider.h
@@ -5,6 +5,7 @@
 
 #include "libaktualizr/config.h"
 #include "libaktualizr/packagemanagerinterface.h"
+#include "libaktualizr/types.h"
 
 class INvStorage;
 
@@ -15,9 +16,8 @@ class SecondaryProvider {
   friend class SecondaryProviderBuilder;
 
   bool getMetadata(Uptane::MetaBundle* meta_bundle, const Uptane::Target& target) const;
-  bool getDirectorMetadata(std::string* root, std::string* targets) const;
-  bool getImageRepoMetadata(std::string* root, std::string* timestamp, std::string* snapshot,
-                            std::string* targets) const;
+  bool getDirectorMetadata(Uptane::MetaBundle* meta_bundle) const;
+  bool getImageRepoMetadata(Uptane::MetaBundle* meta_bundle, const Uptane::Target& target) const;
   std::string getTreehubCredentials() const;
   std::ifstream getTargetFileHandle(const Uptane::Target& target) const;
 

--- a/include/libaktualizr/types.h
+++ b/include/libaktualizr/types.h
@@ -18,6 +18,13 @@ std::ostream &operator<<(std::ostream &os, ProvisionMode mode);
 enum class StorageType { kFileSystem = 0, kSqlite };
 std::ostream &operator<<(std::ostream &os, StorageType stype);
 
+enum class VerificationType {
+  kFull = 0,
+  kTuf
+  // TODO: kPartial
+};
+std::ostream &operator<<(std::ostream &os, VerificationType vtype);
+
 namespace utils {
 /**
  * @brief The BasedPath class
@@ -454,6 +461,28 @@ class Manifest : public Json::Value {
   std::string signedBody() const;
   bool verifySignature(const PublicKey &pub_key) const;
 };
+
+static inline VerificationType VerificationTypeFromString(const std::string &vt_str) {
+  if (vt_str == "Tuf") {
+    return VerificationType::kTuf;
+  } else {
+    return VerificationType::kFull;
+  }
+}
+
+static inline std::string VerificationTypeToString(const VerificationType vtype) {
+  std::string type_s;
+  switch (vtype) {
+    case VerificationType::kFull:
+    default:
+      type_s = "Full";
+      break;
+    case VerificationType::kTuf:
+      type_s = "Tuf";
+      break;
+  }
+  return type_s;
+}
 
 }  // namespace Uptane
 

--- a/include/libaktualizr/types.h
+++ b/include/libaktualizr/types.h
@@ -25,8 +25,6 @@ namespace utils {
  *
  * The intent is to avoid unintentional use of the "naked" relative path by
  * mandating a base directory for each instantiation.
- *
- * TODO has to be moved into Utils namespace
  */
 class BasedPath {
  public:

--- a/include/libaktualizr/types.h
+++ b/include/libaktualizr/types.h
@@ -462,8 +462,9 @@ class Manifest : public Json::Value {
   bool verifySignature(const PublicKey &pub_key) const;
 };
 
-static inline VerificationType VerificationTypeFromString(const std::string &vt_str) {
-  if (vt_str == "Tuf") {
+static inline VerificationType VerificationTypeFromString(std::string vt_str) {
+  std::transform(vt_str.begin(), vt_str.end(), vt_str.begin(), ::tolower);
+  if (vt_str == "tuf") {
     return VerificationType::kTuf;
   } else {
     return VerificationType::kFull;

--- a/src/aktualizr_primary/primary_secondary_registration_test.cc
+++ b/src/aktualizr_primary/primary_secondary_registration_test.cc
@@ -42,6 +42,8 @@ TEST(PrimarySecondaryReg, SecondariesMigration) {
   storage->storeEcuSerials({{primary_serial, primary_hwid}, {secondary_serial, secondary_hwid}});
   storage->storeEcuRegistered();
 
+  // Also test backwards compatibility with verification_type here. Don't set
+  // it but expect it to be set to Full.
   sec_conf["IP"]["secondary_wait_port"] = 9030;
   sec_conf["IP"]["secondary_wait_timeout"] = 1;
   sec_conf["IP"]["secondaries"] = Json::arrayValue;
@@ -71,7 +73,7 @@ TEST(PrimarySecondaryReg, SecondariesMigration) {
     EXPECT_EQ(secs_info.size(), 1);
     EXPECT_EQ(secs_info[0].serial.ToString(), secondary_serial.ToString());
     EXPECT_EQ(secs_info[0].type, "IP");
-    EXPECT_EQ(secs_info[0].extra, R"({"ip":"127.0.0.1","port":9061})");
+    EXPECT_EQ(secs_info[0].extra, R"({"ip":"127.0.0.1","port":9061,"verification_type":"Full"})");
   }
 
   {
@@ -87,7 +89,7 @@ TEST(PrimarySecondaryReg, SecondariesMigration) {
     EXPECT_EQ(secs_info.size(), 1);
     EXPECT_EQ(secs_info[0].serial.ToString(), secondary_serial.ToString());
     EXPECT_EQ(secs_info[0].type, "IP");
-    EXPECT_EQ(secs_info[0].extra, R"({"ip":"127.0.0.1","port":9061})");
+    EXPECT_EQ(secs_info[0].extra, R"({"ip":"127.0.0.1","port":9061,"verification_type":"Full"})");
   }
 }
 

--- a/src/aktualizr_primary/secondary_config.cc
+++ b/src/aktualizr_primary/secondary_config.cc
@@ -37,8 +37,8 @@ config file example
                 "secondaries_wait_port": 9040,
                 "secondaries_wait_timeout": 20,
                 "secondaries": [
-                        {"addr": "127.0.0.1:9031"}
-                        {"addr": "127.0.0.1:9032"}
+                        {"addr": "127.0.0.1:9031", "verification_type": "Full"}
+                        {"addr": "127.0.0.1:9032", "verification_type": "Tuf"}
                 ]
   },
   "socketcan": {
@@ -101,7 +101,12 @@ void JsonConfigParser::createIPSecondariesCfg(Configs& configs, const Json::Valu
 
   for (const auto& secondary : secondaries) {
     auto addr = getIPAndPort(secondary[IPSecondaryConfig::AddrField].asString());
-    IPSecondaryConfig sec_cfg{addr.first, addr.second};
+    // Backwards compatibility: assume full verification if not specified.
+    VerificationType vtype = VerificationType::kFull;
+    if (secondary.isMember(IPSecondaryConfig::VerificationField)) {
+      vtype = Uptane::VerificationTypeFromString(secondary[IPSecondaryConfig::VerificationField].asString());
+    }
+    IPSecondaryConfig sec_cfg{addr.first, addr.second, vtype};
 
     LOG_INFO << "   found IP secondary config: " << sec_cfg;
     resultant_cfg->secondaries_cfg.push_back(sec_cfg);

--- a/src/aktualizr_primary/secondary_config.h
+++ b/src/aktualizr_primary/secondary_config.h
@@ -1,10 +1,12 @@
 #ifndef SECONDARY_CONFIG_H_
 #define SECONDARY_CONFIG_H_
 
-#include <json/json.h>
-#include <boost/filesystem.hpp>
 #include <unordered_map>
 
+#include <json/json.h>
+#include <boost/filesystem.hpp>
+
+#include "libaktualizr/types.h"
 #include "primary/secondary_config.h"
 #include "virtualsecondary.h"
 
@@ -13,17 +15,20 @@ namespace Primary {
 class IPSecondaryConfig {
  public:
   static constexpr const char* const AddrField{"addr"};
+  static constexpr const char* const VerificationField{"verification_type"};
 
-  IPSecondaryConfig(std::string addr_ip, uint16_t addr_port) : ip(std::move(addr_ip)), port(addr_port) {}
+  IPSecondaryConfig(std::string addr_ip, uint16_t addr_port, VerificationType verification_type_in)
+      : ip(std::move(addr_ip)), port(addr_port), verification_type(verification_type_in) {}
 
   friend std::ostream& operator<<(std::ostream& os, const IPSecondaryConfig& cfg) {
-    os << "(addr: " << cfg.ip << ":" << cfg.port << ")";
+    os << "(addr: " << cfg.ip << ":" << cfg.port << " verification_type: " << cfg.verification_type << ")";
     return os;
   }
 
  public:
   const std::string ip;
   const uint16_t port;
+  const VerificationType verification_type;
 };
 
 class IPSecondariesConfig : public SecondaryConfig {

--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -1,14 +1,17 @@
 #include "aktualizr_secondary.h"
 
+#include <sys/types.h>
+#include <memory>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/optional.hpp>
+
 #include "crypto/keymanager.h"
 #include "logging/logging.h"
 #include "storage/invstorage.h"
 #include "update_agent.h"
 #include "uptane/manifest.h"
 #include "utilities/utils.h"
-
-#include <sys/types.h>
-#include <memory>
 
 AktualizrSecondary::AktualizrSecondary(AktualizrSecondaryConfig config, std::shared_ptr<INvStorage> storage)
     : config_(std::move(config)),
@@ -32,9 +35,7 @@ Uptane::Manifest AktualizrSecondary::getManifest() const {
   return manifest;
 }
 
-data::InstallationResult AktualizrSecondary::putMetadata(const Metadata& metadata) {
-  return doFullVerification(metadata);
-}
+data::InstallationResult AktualizrSecondary::putMetadata(const Metadata& metadata) { return verifyMetadata(metadata); }
 
 data::InstallationResult AktualizrSecondary::install() {
   if (!pending_target_.IsValid()) {
@@ -66,23 +67,25 @@ data::InstallationResult AktualizrSecondary::install() {
   return result;
 }
 
-data::InstallationResult AktualizrSecondary::doFullVerification(const Metadata& metadata) {
+data::InstallationResult AktualizrSecondary::verifyMetadata(const Metadata& metadata) {
   // 5.4.4.2. Full verification  https://uptane.github.io/uptane-standard/uptane-standard.html#metadata_verification
 
   // 1. Load and verify the current time or the most recent securely attested time.
   //    We trust the time that the given system/ECU provides.
   TimeStamp now(TimeStamp::Now());
 
-  // 2. Download and check the Root metadata file from the Director repository.
-  // 3. NOT SUPPORTED: Download and check the Timestamp metadata file from the Director repository.
-  // 4. NOT SUPPORTED: Download and check the Snapshot metadata file from the Director repository.
-  // 5. Download and check the Targets metadata file from the Director repository.
-  try {
-    director_repo_.updateMeta(*storage_, metadata);
-  } catch (const std::exception& e) {
-    LOG_ERROR << "Failed to update Director metadata: " << e.what();
-    return data::InstallationResult(data::ResultCode::Numeric::kVerificationFailed,
-                                    std::string("Failed to update Director metadata: ") + e.what());
+  if (config_.uptane.verification_type == VerificationType::kFull) {
+    // 2. Download and check the Root metadata file from the Director repository.
+    // 3. NOT SUPPORTED: Download and check the Timestamp metadata file from the Director repository.
+    // 4. NOT SUPPORTED: Download and check the Snapshot metadata file from the Director repository.
+    // 5. Download and check the Targets metadata file from the Director repository.
+    try {
+      director_repo_.updateMeta(*storage_, metadata);
+    } catch (const std::exception& e) {
+      LOG_ERROR << "Failed to update Director metadata: " << e.what();
+      return data::InstallationResult(data::ResultCode::Numeric::kVerificationFailed,
+                                      std::string("Failed to update Director metadata: ") + e.what());
+    }
   }
 
   // 6. Download and check the Root metadata file from the Image repository.
@@ -97,14 +100,83 @@ data::InstallationResult AktualizrSecondary::doFullVerification(const Metadata& 
                                     std::string("Failed to update Image repo metadata: ") + e.what());
   }
 
-  // 10. Verify that Targets metadata from the Director and Image repositories match.
-  if (!director_repo_.matchTargetsWithImageTargets(*(image_repo_.getTargets()))) {
-    LOG_ERROR << "Targets metadata from the Director and Image repositories do not match";
-    return data::InstallationResult(data::ResultCode::Numeric::kVerificationFailed,
-                                    "Targets metadata from the Director and Image repositories do not match");
+  data::InstallationResult result = findTargets();
+  if (result.isSuccess()) {
+    LOG_INFO << "Metadata verified, new update found.";
+  }
+  return result;
+}
+
+void AktualizrSecondary::initPendingTargetIfAny() {
+  try {
+    if (config_.uptane.verification_type == VerificationType::kFull) {
+      director_repo_.checkMetaOffline(*storage_);
+    } else {
+      image_repo_.checkMetaOffline(*storage_);
+    }
+  } catch (const std::exception& e) {
+    LOG_INFO << "No valid metadata found in storage.";
+    return;
   }
 
-  auto targetsForThisEcu = director_repo_.getTargets(serial(), hwID());
+  findTargets();
+}
+
+data::InstallationResult AktualizrSecondary::findTargets() {
+  std::vector<Uptane::Target> targetsForThisEcu;
+  if (config_.uptane.verification_type == VerificationType::kFull) {
+    // 10. Verify that Targets metadata from the Director and Image repositories match.
+    if (!director_repo_.matchTargetsWithImageTargets(*(image_repo_.getTargets()))) {
+      LOG_ERROR << "Targets metadata from the Director and Image repositories do not match";
+      return data::InstallationResult(data::ResultCode::Numeric::kVerificationFailed,
+                                      "Targets metadata from the Director and Image repositories do not match");
+    }
+
+    targetsForThisEcu = director_repo_.getTargets(serial(), hwID());
+  } else {
+    const auto& targets = image_repo_.getTargets()->targets;
+    for (auto it = targets.begin(); it != targets.end(); ++it) {
+      auto hwids = it->hardwareIds();
+      auto found_loc = std::find(hwids.cbegin(), hwids.cend(), hwID());
+      if (found_loc != hwids.end()) {
+        if (!targetsForThisEcu.empty()) {
+          auto previous = boost::make_optional<int>(false, 0);
+          auto current = boost::make_optional<int>(false, 0);
+          try {
+            previous = boost::lexical_cast<int>(targetsForThisEcu[0].custom_version());
+          } catch (const boost::bad_lexical_cast&) {
+            LOG_TRACE << "Unable to parse Target custom version: " << targetsForThisEcu[0].custom_version();
+          }
+          try {
+            current = boost::lexical_cast<int>(it->custom_version());
+          } catch (const boost::bad_lexical_cast&) {
+            LOG_TRACE << "Unable to parse Target custom version: " << it->custom_version();
+          }
+          if (!previous && !current) {  // NOLINT(bugprone-branch-clone)
+            // No versions: add this to the vector.
+          } else if (!previous) {  // NOLINT(bugprone-branch-clone)
+            // Previous Target didn't have a version but this does; replace existing Targets with this.
+            targetsForThisEcu.clear();
+          } else if (!current) {  // NOLINT(bugprone-branch-clone)
+            // Current Target doesn't have a version but previous does; ignore this.
+            continue;
+          } else if (previous < current) {
+            // Current Target is newer; replace existing Targets with this.
+            targetsForThisEcu.clear();
+          } else if (previous > current) {
+            // Current Target is older; ignore it.
+            continue;
+          } else {
+            // Same version: add it to the vector.
+          }
+        } else {
+          // First matching Target found; add it to the vector.
+        }
+
+        targetsForThisEcu.push_back(*it);
+      }
+    }
+  }
 
   if (targetsForThisEcu.size() != 1) {
     LOG_ERROR << "Invalid number of targets (should be 1): " << targetsForThisEcu.size();
@@ -120,8 +192,6 @@ data::InstallationResult AktualizrSecondary::doFullVerification(const Metadata& 
   }
 
   pending_target_ = targetsForThisEcu[0];
-
-  LOG_INFO << "Metadata verified, new update found.";
   return data::InstallationResult(data::ResultCode::Numeric::kOk, "");
 }
 
@@ -166,29 +236,6 @@ void AktualizrSecondary::uptaneInitialize() {
   // therefore, by default GARAGE_TARGET_NAME == OSTREE_BRANCHNAME == SOTA_HARDWARE_ID
   // If there is no match then the backend/UI will not render/highlight currently installed version at all/correctly
   storage_->importInstalledVersions(config_.import.base_path);
-}
-
-void AktualizrSecondary::initPendingTargetIfAny() {
-  try {
-    director_repo_.checkMetaOffline(*storage_);
-  } catch (const std::exception& e) {
-    LOG_INFO << "No valid metadata found in storage.";
-    return;
-  }
-
-  auto targetsForThisEcu = director_repo_.getTargets(ecu_serial_, hardware_id_);
-
-  if (targetsForThisEcu.size() != 1) {
-    LOG_ERROR << "Invalid number of targets (should be 1): " << targetsForThisEcu.size();
-    return;
-  }
-
-  if (!isTargetSupported(targetsForThisEcu[0])) {
-    LOG_ERROR << "The given target type is not supported: " << targetsForThisEcu[0].type();
-    return;
-  }
-
-  pending_target_ = targetsForThisEcu[0];
 }
 
 void AktualizrSecondary::registerHandlers() {

--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -2,6 +2,7 @@
 
 #include "crypto/keymanager.h"
 #include "logging/logging.h"
+#include "storage/invstorage.h"
 #include "update_agent.h"
 #include "uptane/manifest.h"
 #include "utilities/utils.h"

--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -7,6 +7,7 @@
 #include <boost/optional.hpp>
 
 #include "crypto/keymanager.h"
+#include "libaktualizr/types.h"
 #include "logging/logging.h"
 #include "storage/invstorage.h"
 #include "update_agent.h"
@@ -320,7 +321,8 @@ AktualizrSecondary::ReturnCode AktualizrSecondary::putMetaHdlr(Asn1Message& in_m
   auto md = in_msg.putMetaReq2();
   Uptane::MetaBundle meta_bundle;
 
-  if (md->directorRepo.present == directorRepo_PR_collection) {
+  if (config_.uptane.verification_type == VerificationType::kFull &&
+      md->directorRepo.present == directorRepo_PR_collection) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
     const int director_meta_count = md->directorRepo.choice.collection.list.count;
     for (int i = 0; i < director_meta_count; i++) {

--- a/src/aktualizr_secondary/aktualizr_secondary.h
+++ b/src/aktualizr_secondary/aktualizr_secondary.h
@@ -50,7 +50,8 @@ class AktualizrSecondary : public MsgDispatcher {
  private:
   static void copyMetadata(Uptane::MetaBundle& meta_bundle, Uptane::RepositoryType repo, const Uptane::Role& role,
                            std::string& json);
-  data::InstallationResult doFullVerification(const Metadata& metadata);
+  data::InstallationResult verifyMetadata(const Metadata& metadata);
+  data::InstallationResult findTargets();
   void uptaneInitialize();
   void registerHandlers();
 

--- a/src/aktualizr_secondary/aktualizr_secondary.h
+++ b/src/aktualizr_secondary/aktualizr_secondary.h
@@ -21,6 +21,7 @@ class AktualizrSecondary : public MsgDispatcher {
   const Uptane::HardwareIdentifier& hwID() const { return hardware_id_; }
   PublicKey publicKey() const;
   Uptane::Manifest getManifest() const;
+  const Uptane::Target& getPendingTarget() const { return pending_target_; }
 
   virtual data::InstallationResult putMetadata(const Metadata& metadata);
   virtual data::InstallationResult putMetadata(const Uptane::MetaBundle& meta_bundle) {
@@ -40,7 +41,6 @@ class AktualizrSecondary : public MsgDispatcher {
   virtual data::InstallationResult applyPendingInstall(const Uptane::Target& target) = 0;
 
   // protected interface to be used by child classes
-  Uptane::Target& pendingTarget() { return pending_target_; }
   std::shared_ptr<INvStorage>& storage() { return storage_; }
   Uptane::DirectorRepository& directorRepo() { return director_repo_; }
   std::shared_ptr<KeyManager>& keyMngr() { return keys_; }

--- a/src/aktualizr_secondary/aktualizr_secondary.h
+++ b/src/aktualizr_secondary/aktualizr_secondary.h
@@ -4,7 +4,6 @@
 #include "aktualizr_secondary_config.h"
 #include "aktualizr_secondary_metadata.h"
 #include "msg_handler.h"
-#include "storage/invstorage.h"
 #include "uptane/directorrepository.h"
 #include "uptane/imagerepository.h"
 #include "uptane/manifest.h"
@@ -42,8 +41,7 @@ class AktualizrSecondary : public MsgDispatcher {
 
   // protected interface to be used by child classes
   Uptane::Target& pendingTarget() { return pending_target_; }
-  INvStorage& storage() { return *storage_; }
-  std::shared_ptr<INvStorage>& storagePtr() { return storage_; }
+  std::shared_ptr<INvStorage>& storage() { return storage_; }
   Uptane::DirectorRepository& directorRepo() { return director_repo_; }
   std::shared_ptr<KeyManager>& keyMngr() { return keys_; }
 

--- a/src/aktualizr_secondary/aktualizr_secondary_config.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.cc
@@ -2,6 +2,35 @@
 
 #include <sstream>
 
+std::ostream& operator<<(std::ostream& os, VerificationType type) {
+  std::string type_s;
+  switch (type) {
+    case VerificationType::kFull:
+    default:
+      type_s = "Full";
+      break;
+    case VerificationType::kTuf:
+      type_s = "Tuf";
+      break;
+  }
+  os << '"' << type_s << '"';
+  return os;
+}
+
+template <>
+inline void CopyFromConfig(VerificationType& dest, const std::string& option_name,
+                           const boost::property_tree::ptree& pt) {
+  boost::optional<std::string> value = pt.get_optional<std::string>(option_name);
+  if (value.is_initialized()) {
+    std::string verification_type{StripQuotesFromStrings(value.get())};
+    if (verification_type == "Tuf") {
+      dest = VerificationType::kTuf;
+    } else {
+      dest = VerificationType::kFull;
+    }
+  }
+}
+
 void AktualizrSecondaryNetConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt) {
   CopyFromConfig(port, "port", pt);
   CopyFromConfig(primary_ip, "primary_ip", pt);
@@ -20,6 +49,7 @@ void AktualizrSecondaryUptaneConfig::updateFromPropertyTree(const boost::propert
   CopyFromConfig(key_source, "key_source", pt);
   CopyFromConfig(key_type, "key_type", pt);
   CopyFromConfig(force_install_completion, "force_install_completion", pt);
+  CopyFromConfig(verification_type, "verification_type", pt);
 }
 
 void AktualizrSecondaryUptaneConfig::writeToStream(std::ostream& out_stream) const {
@@ -28,6 +58,7 @@ void AktualizrSecondaryUptaneConfig::writeToStream(std::ostream& out_stream) con
   writeOption(out_stream, key_source, "key_source");
   writeOption(out_stream, key_type, "key_type");
   writeOption(out_stream, force_install_completion, "force_install_completion");
+  writeOption(out_stream, verification_type, "verification_type");
 }
 
 AktualizrSecondaryConfig::AktualizrSecondaryConfig(const boost::program_options::variables_map& cmd) {

--- a/src/aktualizr_secondary/aktualizr_secondary_config.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.cc
@@ -2,32 +2,12 @@
 
 #include <sstream>
 
-std::ostream& operator<<(std::ostream& os, VerificationType type) {
-  std::string type_s;
-  switch (type) {
-    case VerificationType::kFull:
-    default:
-      type_s = "Full";
-      break;
-    case VerificationType::kTuf:
-      type_s = "Tuf";
-      break;
-  }
-  os << '"' << type_s << '"';
-  return os;
-}
-
 template <>
 inline void CopyFromConfig(VerificationType& dest, const std::string& option_name,
                            const boost::property_tree::ptree& pt) {
   boost::optional<std::string> value = pt.get_optional<std::string>(option_name);
   if (value.is_initialized()) {
-    std::string verification_type{StripQuotesFromStrings(value.get())};
-    if (verification_type == "Tuf") {
-      dest = VerificationType::kTuf;
-    } else {
-      dest = VerificationType::kFull;
-    }
+    dest = Uptane::VerificationTypeFromString(StripQuotesFromStrings(value.get()));
   }
 }
 

--- a/src/aktualizr_secondary/aktualizr_secondary_config.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.h
@@ -6,13 +6,8 @@
 #include <boost/property_tree/ini_parser.hpp>
 
 #include "libaktualizr/config.h"
+#include "libaktualizr/types.h"
 #include "utilities/config_utils.h"
-
-enum class VerificationType {
-  kFull = 0,
-  kTuf
-  // TODO: kPartial
-};
 
 // Try to keep the order of config options the same as in
 // AktualizrSecondaryConfig::writeToStream() and

--- a/src/aktualizr_secondary/aktualizr_secondary_config.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.h
@@ -8,6 +8,12 @@
 #include "libaktualizr/config.h"
 #include "utilities/config_utils.h"
 
+enum class VerificationType {
+  kFull = 0,
+  kTuf
+  // TODO: kPartial
+};
+
 // Try to keep the order of config options the same as in
 // AktualizrSecondaryConfig::writeToStream() and
 // AktualizrSecondaryConfig::updateFromPropertyTree().
@@ -27,6 +33,7 @@ struct AktualizrSecondaryUptaneConfig {
   CryptoSource key_source{CryptoSource::kFile};
   KeyType key_type{KeyType::kRSA2048};
   bool force_install_completion{false};
+  VerificationType verification_type{VerificationType::kFull};
 
   void updateFromPropertyTree(const boost::property_tree::ptree& pt);
   void writeToStream(std::ostream& out_stream) const;

--- a/src/aktualizr_secondary/aktualizr_secondary_config_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_config_test.cc
@@ -22,6 +22,7 @@ TEST(aktualizr_secondary_config, config_toml_parsing) {
   EXPECT_EQ(conf.pacman.sysroot, boost::filesystem::path("testsysroot"));
   EXPECT_EQ(conf.pacman.ostree_server, std::string("test_server"));
   EXPECT_EQ(conf.pacman.packages_file, boost::filesystem::path("/test_packages"));
+  EXPECT_EQ(conf.uptane.verification_type, VerificationType::kFull);
 }
 
 /* We don't normally dump the config to file, but we do write it to the log. */

--- a/src/aktualizr_secondary/aktualizr_secondary_file.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_file.cc
@@ -35,13 +35,13 @@ AktualizrSecondaryFile::AktualizrSecondaryFile(const AktualizrSecondaryConfig& c
 void AktualizrSecondaryFile::initialize() { initPendingTargetIfAny(); }
 
 data::InstallationResult AktualizrSecondaryFile::receiveData(const uint8_t* data, size_t size) {
-  if (!pendingTarget().IsValid()) {
+  if (!getPendingTarget().IsValid()) {
     LOG_ERROR << "Aborting image download; no valid target found.";
     return data::InstallationResult(data::ResultCode::Numeric::kGeneralError,
                                     "Aborting image download; no valid target found.");
   }
 
-  return update_agent_->receiveData(pendingTarget(), data, size);
+  return update_agent_->receiveData(getPendingTarget(), data, size);
 }
 
 bool AktualizrSecondaryFile::isTargetSupported(const Uptane::Target& target) const {

--- a/src/aktualizr_secondary/aktualizr_secondary_file.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_file.cc
@@ -20,7 +20,7 @@ AktualizrSecondaryFile::AktualizrSecondaryFile(const AktualizrSecondaryConfig& c
     boost::optional<Uptane::Target> current_version;
     boost::optional<Uptane::Target> pending_version;
     auto installed_version_res =
-        AktualizrSecondary::storage().loadInstalledVersions("", &current_version, &pending_version);
+        AktualizrSecondary::storage()->loadInstalledVersions("", &current_version, &pending_version);
 
     if (installed_version_res && !!current_version) {
       current_target_name = current_version->filename();

--- a/src/aktualizr_secondary/aktualizr_secondary_metadata.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_metadata.cc
@@ -1,10 +1,18 @@
 #include "aktualizr_secondary_metadata.h"
 
 Metadata::Metadata(Uptane::MetaBundle meta_bundle_in) : meta_bundle_(std::move(meta_bundle_in)) {
-  director_root_version_ = Uptane::Version(Uptane::extractVersionUntrusted(
-      Uptane::getMetaFromBundle(meta_bundle_, Uptane::RepositoryType::Director(), Uptane::Role::Root())));
-  image_root_version_ = Uptane::Version(Uptane::extractVersionUntrusted(
-      Uptane::getMetaFromBundle(meta_bundle_, Uptane::RepositoryType::Image(), Uptane::Role::Root())));
+  try {
+    director_root_version_ = Uptane::Version(Uptane::extractVersionUntrusted(
+        Uptane::getMetaFromBundle(meta_bundle_, Uptane::RepositoryType::Director(), Uptane::Role::Root())));
+  } catch (const std::exception& e) {
+    LOG_DEBUG << "Failed to read Director Root version: " << e.what();
+  }
+  try {
+    image_root_version_ = Uptane::Version(Uptane::extractVersionUntrusted(
+        Uptane::getMetaFromBundle(meta_bundle_, Uptane::RepositoryType::Image(), Uptane::Role::Root())));
+  } catch (const std::exception& e) {
+    LOG_DEBUG << "Failed to read Image repo Root version: " << e.what();
+  }
 }
 
 void Metadata::fetchRole(std::string* result, int64_t maxsize, Uptane::RepositoryType repo, const Uptane::Role& role,

--- a/src/aktualizr_secondary/aktualizr_secondary_ostree.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_ostree.cc
@@ -12,7 +12,7 @@ AktualizrSecondaryOstree::AktualizrSecondaryOstree(const AktualizrSecondaryConfi
                                                                    std::placeholders::_1, std::placeholders::_2));
 
   std::shared_ptr<OstreeManager> pack_man =
-      std::make_shared<OstreeManager>(config.pacman, config.bootloader, AktualizrSecondary::storagePtr(), nullptr);
+      std::make_shared<OstreeManager>(config.pacman, config.bootloader, AktualizrSecondary::storage(), nullptr);
   update_agent_ =
       std::make_shared<OstreeUpdateAgent>(config.pacman.sysroot, keyMngr(), pack_man, config.uptane.ecu_hardware_id);
 }
@@ -26,7 +26,7 @@ void AktualizrSecondaryOstree::initialize() {
     // an installation status of each ECU but store it just for a given secondary ECU
     std::vector<Uptane::Target> installed_versions;
     boost::optional<Uptane::Target> pending_target;
-    AktualizrSecondary::storage().loadInstalledVersions(serial().ToString(), nullptr, &pending_target);
+    AktualizrSecondary::storage()->loadInstalledVersions(serial().ToString(), nullptr, &pending_target);
 
     if (!!pending_target) {
       data::InstallationResult install_res =
@@ -36,20 +36,20 @@ void AktualizrSecondaryOstree::initialize() {
       install_res = applyPendingInstall(*pending_target);
 
       if (install_res.result_code != data::ResultCode::Numeric::kNeedCompletion) {
-        AktualizrSecondary::storage().saveEcuInstallationResult(serial(), install_res);
+        AktualizrSecondary::storage()->saveEcuInstallationResult(serial(), install_res);
 
         if (install_res.isSuccess()) {
           LOG_INFO << "Pending update has been successfully applied: " << pending_target->sha256Hash();
-          AktualizrSecondary::storage().saveInstalledVersion(serial().ToString(), *pending_target,
-                                                             InstalledVersionUpdateMode::kCurrent);
+          AktualizrSecondary::storage()->saveInstalledVersion(serial().ToString(), *pending_target,
+                                                              InstalledVersionUpdateMode::kCurrent);
         } else {
           LOG_ERROR << "Application of the pending update has failed: (" << install_res.result_code.toString() << ")"
                     << install_res.description;
-          AktualizrSecondary::storage().saveInstalledVersion(serial().ToString(), *pending_target,
-                                                             InstalledVersionUpdateMode::kNone);
+          AktualizrSecondary::storage()->saveInstalledVersion(serial().ToString(), *pending_target,
+                                                              InstalledVersionUpdateMode::kNone);
         }
 
-        directorRepo().dropTargets(AktualizrSecondary::storage());
+        directorRepo().dropTargets(*AktualizrSecondary::storage());
       } else {
         LOG_INFO << "Pending update hasn't been applied because a reboot hasn't been detected";
       }

--- a/src/aktualizr_secondary/aktualizr_secondary_ostree.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_ostree.cc
@@ -69,17 +69,13 @@ MsgHandler::ReturnCode AktualizrSecondaryOstree::downloadOstreeRev(Asn1Message& 
 }
 
 data::InstallationResult AktualizrSecondaryOstree::downloadOstreeUpdate(const std::string& packed_tls_creds) {
-  if (!pendingTarget().IsValid()) {
+  if (!getPendingTarget().IsValid()) {
     LOG_ERROR << "Aborting image download; no valid target found.";
     return data::InstallationResult(data::ResultCode::Numeric::kGeneralError,
                                     "Aborting image download; no valid target found.");
   }
 
-  auto result = update_agent_->downloadTargetRev(pendingTarget(), packed_tls_creds);
-  if (!result.isSuccess()) {
-    pendingTarget() = Uptane::Target::Unknown();
-  }
-  return result;
+  return update_agent_->downloadTargetRev(getPendingTarget(), packed_tls_creds);
 }
 
 bool AktualizrSecondaryOstree::isTargetSupported(const Uptane::Target& target) const {

--- a/src/aktualizr_secondary/aktualizr_secondary_ostree.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_ostree.h
@@ -2,6 +2,7 @@
 #define AKTUALIZR_SECONDARY_OSTREE_H
 
 #include "aktualizr_secondary.h"
+#include "storage/invstorage.h"
 
 class OstreeUpdateAgent;
 
@@ -21,7 +22,7 @@ class AktualizrSecondaryOstree : public AktualizrSecondary {
   void completeInstall() override;
 
  private:
-  bool hasPendingUpdate() { return storage().hasPendingInstall(); }
+  bool hasPendingUpdate() { return storage()->hasPendingInstall(); }
 
   ReturnCode downloadOstreeRev(Asn1Message& in_msg, Asn1Message& out_msg);
 

--- a/src/aktualizr_secondary/aktualizr_secondary_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_test.cc
@@ -5,6 +5,7 @@
 
 #include "aktualizr_secondary_file.h"
 #include "crypto/keymanager.h"
+#include "libaktualizr/types.h"
 #include "storage/invstorage.h"
 #include "test_utils.h"
 #include "update_agent.h"

--- a/src/aktualizr_secondary/aktualizr_secondary_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_test.cc
@@ -5,6 +5,7 @@
 
 #include "aktualizr_secondary_file.h"
 #include "crypto/keymanager.h"
+#include "storage/invstorage.h"
 #include "test_utils.h"
 #include "update_agent.h"
 #include "update_agent_file.h"

--- a/src/aktualizr_secondary/secondary_rpc_test.cc
+++ b/src/aktualizr_secondary/secondary_rpc_test.cc
@@ -457,7 +457,8 @@ class SecondaryRpcCommon : public ::testing::Test {
         secondary_server_thread_{std::bind(&SecondaryRpcCommon::runSecondaryServer, this)},
         image_file_{"mytarget_image.img", image_size} {
     secondary_server_.wait_until_running();
-    ip_secondary_ = Uptane::IpUptaneSecondary::connectAndCreate("localhost", secondary_server_.port());
+    ip_secondary_ =
+        Uptane::IpUptaneSecondary::connectAndCreate("localhost", secondary_server_.port(), VerificationType::kFull);
 
     config_.pacman.ostree_server = server_;
     config_.pacman.type = PACKAGE_MANAGER_NONE;
@@ -661,13 +662,13 @@ TEST(SecondaryTcpServer, TestIpSecondaryIfSecondaryIsNotRunning) {
   SecondaryInterface::Ptr ip_secondary;
 
   // Try to connect to a non-running Secondary and create a corresponding instance on Primary.
-  ip_secondary = Uptane::IpUptaneSecondary::connectAndCreate("localhost", secondary_port);
+  ip_secondary = Uptane::IpUptaneSecondary::connectAndCreate("localhost", secondary_port, VerificationType::kFull);
   EXPECT_EQ(ip_secondary, nullptr);
 
   // Create Secondary on Primary without actually connecting to Secondary.
-  ip_secondary = std::make_shared<Uptane::IpUptaneSecondary>("localhost", secondary_port, Uptane::EcuSerial("serial"),
-                                                             Uptane::HardwareIdentifier("hwid"),
-                                                             PublicKey("key", KeyType::kED25519));
+  ip_secondary = std::make_shared<Uptane::IpUptaneSecondary>(
+      "localhost", secondary_port, VerificationType::kFull, Uptane::EcuSerial("serial"),
+      Uptane::HardwareIdentifier("hwid"), PublicKey("key", KeyType::kED25519));
 
   TemporaryDirectory temp_dir;
   Config config;

--- a/src/aktualizr_secondary/secondary_rpc_test.cc
+++ b/src/aktualizr_secondary/secondary_rpc_test.cc
@@ -26,13 +26,14 @@ enum class HandlerVersion { kV1, kV2, kV2Failure };
 class SecondaryMock : public MsgDispatcher {
  public:
   SecondaryMock(const Uptane::EcuSerial& serial, const Uptane::HardwareIdentifier& hdw_id, const PublicKey& pub_key,
-                const Uptane::Manifest& manifest, HandlerVersion handler_version = HandlerVersion::kV2)
+                const Uptane::Manifest& manifest, VerificationType vtype, HandlerVersion handler_version)
       : serial_(serial),
         hdw_id_(hdw_id),
         pub_key_(pub_key),
         manifest_(manifest),
         image_filepath_{image_dir_ / "image.bin"},
         hasher_{MultiPartHasher::create(Hash::Type::kSha256)},
+        vtype_{vtype},
         handler_version_(handler_version) {
     registerHandlers();
   }
@@ -162,7 +163,8 @@ class SecondaryMock : public MsgDispatcher {
     return ReturnCode::kOk;
   }
 
-  // This is basically the old implemention from AktualizrSecondary.
+  // This is basically the old implemention from AktualizrSecondary. The v1
+  // protocol never had TUF verification so it isn't accounted for here.
   MsgHandler::ReturnCode putMetaHdlr(Asn1Message& in_msg, Asn1Message& out_msg) {
     auto md = in_msg.putMetaReq();
 
@@ -191,19 +193,22 @@ class SecondaryMock : public MsgDispatcher {
     Uptane::MetaBundle meta_bundle;
 
     EXPECT_EQ(md->directorRepo.present, directorRepo_PR_collection);
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
-    const int director_meta_count = md->directorRepo.choice.collection.list.count;
-    EXPECT_EQ(director_meta_count, 2);
-    for (int i = 0; i < director_meta_count; i++) {
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-union-access)
-      const AKMetaJson_t object = *md->directorRepo.choice.collection.list.array[i];
-      const std::string role = ToString(object.role);
-      std::string json = ToString(object.json);
-      if (role == Uptane::Role::ROOT) {
-        meta_bundle.emplace(std::make_pair(Uptane::RepositoryType::Director(), Uptane::Role::Root()), std::move(json));
-      } else if (role == Uptane::Role::TARGETS) {
-        meta_bundle.emplace(std::make_pair(Uptane::RepositoryType::Director(), Uptane::Role::Targets()),
-                            std::move(json));
+    if (vtype_ == VerificationType::kFull) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+      const int director_meta_count = md->directorRepo.choice.collection.list.count;
+      EXPECT_EQ(director_meta_count, 2);
+      for (int i = 0; i < director_meta_count; i++) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-union-access)
+        const AKMetaJson_t object = *md->directorRepo.choice.collection.list.array[i];
+        const std::string role = ToString(object.role);
+        std::string json = ToString(object.json);
+        if (role == Uptane::Role::ROOT) {
+          meta_bundle.emplace(std::make_pair(Uptane::RepositoryType::Director(), Uptane::Role::Root()),
+                              std::move(json));
+        } else if (role == Uptane::Role::TARGETS) {
+          meta_bundle.emplace(std::make_pair(Uptane::RepositoryType::Director(), Uptane::Role::Targets()),
+                              std::move(json));
+        }
       }
     }
 
@@ -379,6 +384,7 @@ class SecondaryMock : public MsgDispatcher {
   std::unordered_map<unsigned int, Handler> handler_map_;
   std::string tls_creds_;
   std::string received_firmware_data_;
+  VerificationType vtype_;
   HandlerVersion handler_version_;
 };
 
@@ -450,15 +456,19 @@ class SecondaryRpcCommon : public ::testing::Test {
   const std::string image_targets_ = "image-targets";
 
  protected:
-  SecondaryRpcCommon(size_t image_size, HandlerVersion handler_version)
-      : secondary_{Uptane::EcuSerial("serial"), Uptane::HardwareIdentifier("hardware-id"),
-                   PublicKey("pub-key", KeyType::kED25519), Uptane::Manifest(), handler_version},
+  SecondaryRpcCommon(size_t image_size, HandlerVersion handler_version, VerificationType vtype)
+      : secondary_{Uptane::EcuSerial("serial"),
+                   Uptane::HardwareIdentifier("hardware-id"),
+                   PublicKey("pub-key", KeyType::kED25519),
+                   Uptane::Manifest(),
+                   vtype,
+                   handler_version},
         secondary_server_{secondary_, "", 0},
         secondary_server_thread_{std::bind(&SecondaryRpcCommon::runSecondaryServer, this)},
-        image_file_{"mytarget_image.img", image_size} {
+        image_file_{"mytarget_image.img", image_size},
+        vtype_{vtype} {
     secondary_server_.wait_until_running();
-    ip_secondary_ =
-        Uptane::IpUptaneSecondary::connectAndCreate("localhost", secondary_server_.port(), VerificationType::kFull);
+    ip_secondary_ = Uptane::IpUptaneSecondary::connectAndCreate("localhost", secondary_server_.port(), vtype);
 
     config_.pacman.ostree_server = server_;
     config_.pacman.type = PACKAGE_MANAGER_NONE;
@@ -492,10 +502,12 @@ class SecondaryRpcCommon : public ::testing::Test {
   }
 
   void verifyMetadata(const Uptane::MetaBundle& meta_bundle) {
-    EXPECT_EQ(Uptane::getMetaFromBundle(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Root()),
-              director_root_);
-    EXPECT_EQ(Uptane::getMetaFromBundle(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Targets()),
-              director_targets_);
+    if (vtype_ == VerificationType::kFull) {
+      EXPECT_EQ(Uptane::getMetaFromBundle(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Root()),
+                director_root_);
+      EXPECT_EQ(Uptane::getMetaFromBundle(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Targets()),
+                director_targets_);
+    }
     EXPECT_EQ(Uptane::getMetaFromBundle(meta_bundle, Uptane::RepositoryType::Image(), Uptane::Role::Root()),
               image_root_);
     EXPECT_EQ(Uptane::getMetaFromBundle(meta_bundle, Uptane::RepositoryType::Image(), Uptane::Role::Timestamp()),
@@ -592,6 +604,7 @@ class SecondaryRpcCommon : public ::testing::Test {
   SecondaryTcpServer secondary_server_;
   std::thread secondary_server_thread_;
   TargetFile image_file_;
+  VerificationType vtype_;
   SecondaryInterface::Ptr ip_secondary_;
   TemporaryDirectory temp_dir_;
   std::shared_ptr<INvStorage> storage_;
@@ -600,9 +613,9 @@ class SecondaryRpcCommon : public ::testing::Test {
 };
 
 class SecondaryRpcTest : public SecondaryRpcCommon,
-                         public ::testing::WithParamInterface<std::pair<size_t, HandlerVersion>> {
+                         public ::testing::WithParamInterface<std::tuple<size_t, HandlerVersion, VerificationType>> {
  protected:
-  SecondaryRpcTest() : SecondaryRpcCommon(GetParam().first, GetParam().second) {}
+  SecondaryRpcTest() : SecondaryRpcCommon(std::get<0>(GetParam()), std::get<1>(GetParam()), std::get<2>(GetParam())) {}
 };
 
 // Test the serialization/deserialization and the TCP/IP communication implementation
@@ -622,18 +635,27 @@ TEST_P(SecondaryRpcTest, AllRpcCallsTest) {
 /* These tests use a mock of most of the Secondary internals in order to test
  * the RPC mechanism between the Primary and IP Secondary. The tests cover the
  * old/v1/fallback handlers as well as the new/v2 versions. */
-INSTANTIATE_TEST_SUITE_P(
-    SecondaryRpcTestCases, SecondaryRpcTest,
-    ::testing::Values(std::make_pair(1, HandlerVersion::kV2), std::make_pair(1024, HandlerVersion::kV2),
-                      std::make_pair(1024 - 1, HandlerVersion::kV2), std::make_pair(1024 + 1, HandlerVersion::kV2),
-                      std::make_pair(1024 * 10 + 1, HandlerVersion::kV2), std::make_pair(1, HandlerVersion::kV1),
-                      std::make_pair(1024, HandlerVersion::kV1), std::make_pair(1024 - 1, HandlerVersion::kV1),
-                      std::make_pair(1024 + 1, HandlerVersion::kV1), std::make_pair(1024 * 10 + 1, HandlerVersion::kV1),
-                      std::make_pair(1024, HandlerVersion::kV2Failure)));
+INSTANTIATE_TEST_SUITE_P(SecondaryRpcTestCases, SecondaryRpcTest,
+                         ::testing::Values(std::make_tuple(1, HandlerVersion::kV2, VerificationType::kFull),
+                                           std::make_tuple(1024, HandlerVersion::kV2, VerificationType::kFull),
+                                           std::make_tuple(1024 - 1, HandlerVersion::kV2, VerificationType::kFull),
+                                           std::make_tuple(1024 + 1, HandlerVersion::kV2, VerificationType::kFull),
+                                           std::make_tuple(1024 * 10 + 1, HandlerVersion::kV2, VerificationType::kFull),
+                                           std::make_tuple(1, HandlerVersion::kV2, VerificationType::kTuf),
+                                           std::make_tuple(1024, HandlerVersion::kV2, VerificationType::kTuf),
+                                           std::make_tuple(1024 - 1, HandlerVersion::kV2, VerificationType::kTuf),
+                                           std::make_tuple(1024 + 1, HandlerVersion::kV2, VerificationType::kTuf),
+                                           std::make_tuple(1024 * 10 + 1, HandlerVersion::kV2, VerificationType::kTuf),
+                                           std::make_tuple(1, HandlerVersion::kV1, VerificationType::kFull),
+                                           std::make_tuple(1024, HandlerVersion::kV1, VerificationType::kFull),
+                                           std::make_tuple(1024 - 1, HandlerVersion::kV1, VerificationType::kFull),
+                                           std::make_tuple(1024 + 1, HandlerVersion::kV1, VerificationType::kFull),
+                                           std::make_tuple(1024 * 10 + 1, HandlerVersion::kV1, VerificationType::kFull),
+                                           std::make_tuple(1024, HandlerVersion::kV2Failure, VerificationType::kFull)));
 
 class SecondaryRpcUpgrade : public SecondaryRpcCommon {
  protected:
-  SecondaryRpcUpgrade() : SecondaryRpcCommon(1024, HandlerVersion::kV1) {}
+  SecondaryRpcUpgrade() : SecondaryRpcCommon(1024, HandlerVersion::kV1, VerificationType::kFull) {}
 };
 
 /* Test upgrade and downgrade of protocol versions after installation, both for

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -213,15 +213,16 @@ void IpUptaneSecondary::addMetadata(const Uptane::MetaBundle& meta_bundle, const
 data::InstallationResult IpUptaneSecondary::putMetadata_v2(const Uptane::MetaBundle& meta_bundle) {
   Asn1Message::Ptr req(Asn1Message::Empty());
   req->present(AKIpUptaneMes_PR_putMetaReq2);
-
   auto m = req->putMetaReq2();
-  m->directorRepo.present = directorRepo_PR_collection;
-  m->imageRepo.present = imageRepo_PR_collection;
 
+  // TODO: Consider only sending for full verification Secondaries.
+  m->directorRepo.present = directorRepo_PR_collection;
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
   addMetadata(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Root(), m->directorRepo.choice.collection);
   addMetadata(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Targets(),
               m->directorRepo.choice.collection);  // NOLINT(cppcoreguidelines-pro-type-union-access)
+
+  m->imageRepo.present = imageRepo_PR_collection;
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
   addMetadata(meta_bundle, Uptane::RepositoryType::Image(), Uptane::Role::Root(), m->imageRepo.choice.collection);
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -176,8 +176,10 @@ data::InstallationResult IpUptaneSecondary::putMetadata_v1(const Uptane::MetaBun
   req->present(AKIpUptaneMes_PR_putMetaReq);
   auto m = req->putMetaReq();
 
+  m->director.present = director_PR_json;
+  // Technically no Secondary supported TUF verification with the v1 protocol,
+  // so this probably wouldn't work.
   if (verification_type_ != VerificationType::kTuf) {
-    m->director.present = director_PR_json;
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
     SetString(&m->director.choice.json.root,
               getMetaFromBundle(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Root()));
@@ -231,8 +233,8 @@ data::InstallationResult IpUptaneSecondary::putMetadata_v2(const Uptane::MetaBun
   req->present(AKIpUptaneMes_PR_putMetaReq2);
   auto m = req->putMetaReq2();
 
+  m->directorRepo.present = directorRepo_PR_collection;
   if (verification_type_ != VerificationType::kTuf) {
-    m->directorRepo.present = directorRepo_PR_collection;
     addMetadata(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Root(),
                 m->directorRepo.choice.collection);  // NOLINT(cppcoreguidelines-pro-type-union-access)
     addMetadata(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Targets(),

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -12,7 +12,8 @@
 
 namespace Uptane {
 
-SecondaryInterface::Ptr IpUptaneSecondary::connectAndCreate(const std::string& address, unsigned short port) {
+SecondaryInterface::Ptr IpUptaneSecondary::connectAndCreate(const std::string& address, unsigned short port,
+                                                            VerificationType verification_type) {
   LOG_INFO << "Connecting to and getting info about IP Secondary: " << address << ":" << port << "...";
 
   ConnectionSocket con_sock{address, port};
@@ -25,10 +26,11 @@ SecondaryInterface::Ptr IpUptaneSecondary::connectAndCreate(const std::string& a
     return nullptr;
   }
 
-  return create(address, port, *con_sock);
+  return create(address, port, verification_type, *con_sock);
 }
 
-SecondaryInterface::Ptr IpUptaneSecondary::create(const std::string& address, unsigned short port, int con_fd) {
+SecondaryInterface::Ptr IpUptaneSecondary::create(const std::string& address, unsigned short port,
+                                                  VerificationType verification_type, int con_fd) {
   Asn1Message::Ptr req(Asn1Message::Empty());
   req->present(AKIpUptaneMes_PR_getInfoReq);
 
@@ -37,8 +39,8 @@ SecondaryInterface::Ptr IpUptaneSecondary::create(const std::string& address, un
 
   if (resp->present() != AKIpUptaneMes_PR_getInfoResp) {
     LOG_ERROR << "IP Secondary failed to respond to information request at " << address << ":" << port;
-    return std::make_shared<IpUptaneSecondary>(address, port, EcuSerial::Unknown(), HardwareIdentifier::Unknown(),
-                                               PublicKey("", KeyType::kUnknown));
+    return std::make_shared<IpUptaneSecondary>(address, port, verification_type, EcuSerial::Unknown(),
+                                               HardwareIdentifier::Unknown(), PublicKey("", KeyType::kUnknown));
   }
   auto r = resp->getInfoResp();
 
@@ -51,17 +53,17 @@ SecondaryInterface::Ptr IpUptaneSecondary::create(const std::string& address, un
   LOG_INFO << "Got ECU information from IP Secondary: "
            << "hardware ID: " << hw_id << " serial: " << serial;
 
-  return std::make_shared<IpUptaneSecondary>(address, port, serial, hw_id, pub_key);
+  return std::make_shared<IpUptaneSecondary>(address, port, verification_type, serial, hw_id, pub_key);
 }
 
 SecondaryInterface::Ptr IpUptaneSecondary::connectAndCheck(const std::string& address, unsigned short port,
-                                                           EcuSerial serial, HardwareIdentifier hw_id,
-                                                           PublicKey pub_key) {
+                                                           VerificationType verification_type, EcuSerial serial,
+                                                           HardwareIdentifier hw_id, PublicKey pub_key) {
   // try to connect:
   // - if it succeeds compare with what we expect
   // - otherwise, keep using what we know
   try {
-    auto sec = IpUptaneSecondary::connectAndCreate(address, port);
+    auto sec = IpUptaneSecondary::connectAndCreate(address, port, verification_type);
     if (sec != nullptr) {
       auto s = sec->getSerial();
       if (s != serial && serial != EcuSerial::Unknown()) {
@@ -88,12 +90,18 @@ SecondaryInterface::Ptr IpUptaneSecondary::connectAndCheck(const std::string& ad
     LOG_WARNING << "Could not connect to IP Secondary at " << address << ":" << port << " with serial " << serial;
   }
 
-  return std::make_shared<IpUptaneSecondary>(address, port, std::move(serial), std::move(hw_id), std::move(pub_key));
+  return std::make_shared<IpUptaneSecondary>(address, port, verification_type, std::move(serial), std::move(hw_id),
+                                             std::move(pub_key));
 }
 
-IpUptaneSecondary::IpUptaneSecondary(const std::string& address, unsigned short port, EcuSerial serial,
-                                     HardwareIdentifier hw_id, PublicKey pub_key)
-    : addr_{address, port}, serial_{std::move(serial)}, hw_id_{std::move(hw_id)}, pub_key_{std::move(pub_key)} {}
+IpUptaneSecondary::IpUptaneSecondary(const std::string& address, unsigned short port,
+                                     VerificationType verification_type, EcuSerial serial, HardwareIdentifier hw_id,
+                                     PublicKey pub_key)
+    : addr_{address, port},
+      verification_type_{verification_type},
+      serial_{std::move(serial)},
+      hw_id_{std::move(hw_id)},
+      pub_key_{std::move(pub_key)} {}
 
 /* Determine the best protocol version to use for this Secondary. This did not
  * exist for v1 and thus only works for v2 and beyond. It would be great if we
@@ -136,7 +144,13 @@ void IpUptaneSecondary::getSecondaryVersion() const {
 
 data::InstallationResult IpUptaneSecondary::putMetadata(const Target& target) {
   Uptane::MetaBundle meta_bundle;
-  if (!secondary_provider_->getMetadata(&meta_bundle, target)) {
+  bool load_result;
+  if (verification_type_ == VerificationType::kTuf) {
+    load_result = secondary_provider_->getImageRepoMetadata(&meta_bundle, target);
+  } else {
+    load_result = secondary_provider_->getMetadata(&meta_bundle, target);
+  }
+  if (!load_result) {
     return data::InstallationResult(data::ResultCode::Numeric::kInternalError,
                                     "Unable to load stored metadata from Primary");
   }
@@ -160,15 +174,17 @@ data::InstallationResult IpUptaneSecondary::putMetadata(const Target& target) {
 data::InstallationResult IpUptaneSecondary::putMetadata_v1(const Uptane::MetaBundle& meta_bundle) {
   Asn1Message::Ptr req(Asn1Message::Empty());
   req->present(AKIpUptaneMes_PR_putMetaReq);
-
   auto m = req->putMetaReq();
-  m->director.present = director_PR_json;
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
-  SetString(&m->director.choice.json.root,
-            getMetaFromBundle(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Root()));
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
-  SetString(&m->director.choice.json.targets,
-            getMetaFromBundle(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Targets()));
+
+  if (verification_type_ != VerificationType::kTuf) {
+    m->director.present = director_PR_json;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+    SetString(&m->director.choice.json.root,
+              getMetaFromBundle(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Root()));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+    SetString(&m->director.choice.json.targets,
+              getMetaFromBundle(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Targets()));
+  }
 
   m->image.present = image_PR_json;
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
@@ -215,12 +231,13 @@ data::InstallationResult IpUptaneSecondary::putMetadata_v2(const Uptane::MetaBun
   req->present(AKIpUptaneMes_PR_putMetaReq2);
   auto m = req->putMetaReq2();
 
-  // TODO: Consider only sending for full verification Secondaries.
-  m->directorRepo.present = directorRepo_PR_collection;
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
-  addMetadata(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Root(), m->directorRepo.choice.collection);
-  addMetadata(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Targets(),
-              m->directorRepo.choice.collection);  // NOLINT(cppcoreguidelines-pro-type-union-access)
+  if (verification_type_ != VerificationType::kTuf) {
+    m->directorRepo.present = directorRepo_PR_collection;
+    addMetadata(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Root(),
+                m->directorRepo.choice.collection);  // NOLINT(cppcoreguidelines-pro-type-union-access)
+    addMetadata(meta_bundle, Uptane::RepositoryType::Director(), Uptane::Role::Targets(),
+                m->directorRepo.choice.collection);  // NOLINT(cppcoreguidelines-pro-type-union-access)
+  }
 
   m->imageRepo.present = imageRepo_PR_collection;
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)

--- a/src/libaktualizr-posix/ipuptanesecondary.h
+++ b/src/libaktualizr-posix/ipuptanesecondary.h
@@ -2,6 +2,7 @@
 #define UPTANE_IPUPTANESECONDARY_H_
 
 #include "libaktualizr/secondaryinterface.h"
+#include "libaktualizr/types.h"
 
 struct AKMetaCollection;
 typedef struct AKMetaCollection AKMetaCollection_t;
@@ -10,14 +11,17 @@ namespace Uptane {
 
 class IpUptaneSecondary : public SecondaryInterface {
  public:
-  static SecondaryInterface::Ptr connectAndCreate(const std::string& address, unsigned short port);
-  static SecondaryInterface::Ptr create(const std::string& address, unsigned short port, int con_fd);
+  static SecondaryInterface::Ptr connectAndCreate(const std::string& address, unsigned short port,
+                                                  VerificationType verification_type);
+  static SecondaryInterface::Ptr create(const std::string& address, unsigned short port,
+                                        VerificationType verification_type, int con_fd);
 
-  static SecondaryInterface::Ptr connectAndCheck(const std::string& address, unsigned short port, EcuSerial serial,
+  static SecondaryInterface::Ptr connectAndCheck(const std::string& address, unsigned short port,
+                                                 VerificationType verification_type, EcuSerial serial,
                                                  HardwareIdentifier hw_id, PublicKey pub_key);
 
-  explicit IpUptaneSecondary(const std::string& address, unsigned short port, EcuSerial serial,
-                             HardwareIdentifier hw_id, PublicKey pub_key);
+  explicit IpUptaneSecondary(const std::string& address, unsigned short port, VerificationType verification_type,
+                             EcuSerial serial, HardwareIdentifier hw_id, PublicKey pub_key);
 
   std::string Type() const override { return "IP"; }
   EcuSerial getSerial() const override { return serial_; };
@@ -55,7 +59,8 @@ class IpUptaneSecondary : public SecondaryInterface {
   data::InstallationResult uploadFirmwareData(const uint8_t* data, size_t size);
 
   std::shared_ptr<SecondaryProvider> secondary_provider_;
-  std::pair<std::string, uint16_t> addr_;
+  const std::pair<std::string, uint16_t> addr_;
+  const VerificationType verification_type_;
   const EcuSerial serial_;
   const HardwareIdentifier hw_id_;
   const PublicKey pub_key_;

--- a/src/libaktualizr/primary/aktualizr_lite_test.cc
+++ b/src/libaktualizr/primary/aktualizr_lite_test.cc
@@ -36,12 +36,9 @@ class TufRepoMock {
   const std::string& url() { return url_; }
 
   Uptane::Target add_target(const std::string& target_name, const std::string& hash, const std::string& hardware_id) {
-    Delegation empty_delegetion{};
-    Hash hash_obj{Hash::Type::kSha256, hash};
     Json::Value custom_json;
     custom_json["targetFormat"] = "OSTREE";
-
-    repo_.addCustomImage(target_name, hash_obj, 0, hardware_id, "", empty_delegetion, custom_json);
+    repo_.addCustomImage(target_name, Hash(Hash::Type::kSha256, hash), 0, hardware_id, "", Delegation(), custom_json);
 
     Json::Value target;
     target["length"] = 0;

--- a/src/libaktualizr/primary/secondary_provider_builder.h
+++ b/src/libaktualizr/primary/secondary_provider_builder.h
@@ -10,7 +10,7 @@ class SecondaryProviderBuilder {
   static std::shared_ptr<SecondaryProvider> Build(
       Config& config, const std::shared_ptr<const INvStorage>& storage,
       const std::shared_ptr<const PackageManagerInterface>& package_manager) {
-    return std::shared_ptr<SecondaryProvider>(new SecondaryProvider(config, storage, package_manager));
+    return std::make_shared<SecondaryProvider>(SecondaryProvider(config, storage, package_manager));
   }
   SecondaryProviderBuilder(SecondaryProviderBuilder&&) = delete;
   SecondaryProviderBuilder(const SecondaryProviderBuilder&) = delete;

--- a/src/libaktualizr/uptane/directorrepository.cc
+++ b/src/libaktualizr/uptane/directorrepository.cc
@@ -148,14 +148,18 @@ void DirectorRepository::dropTargets(INvStorage& storage) {
   }
 }
 
-bool DirectorRepository::matchTargetsWithImageTargets(const Uptane::Targets& image_targets) const {
+bool DirectorRepository::matchTargetsWithImageTargets(
+    const std::shared_ptr<const Uptane::Targets>& image_targets) const {
   // step 10 of https://uptane.github.io/papers/ieee-isto-6100.1.0.0.uptane-standard.html#rfc.section.5.4.4.2
   // TODO(OTA-4800): support delegations. Consider reusing findTargetInDelegationTree(),
   // but it would need to be moved into a common place to be resued by Primary and Secondary.
   // Currently this is only used by aktualizr-secondary, but according to the
   // Standard, "A Secondary ECU MAY elect to perform this check only on the
   // metadata for the image it will install".
-  const auto& image_target_array = image_targets.targets;
+  if (image_targets == nullptr) {
+    return false;
+  }
+  const auto& image_target_array = image_targets->targets;
   const auto& director_target_array = targets.targets;
 
   for (const auto& director_target : director_target_array) {

--- a/src/libaktualizr/uptane/directorrepository.h
+++ b/src/libaktualizr/uptane/directorrepository.h
@@ -25,7 +25,7 @@ class DirectorRepository : public RepositoryCommon {
   void dropTargets(INvStorage& storage);
 
   void updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher) override;
-  bool matchTargetsWithImageTargets(const Uptane::Targets& image_targets) const;
+  bool matchTargetsWithImageTargets(const std::shared_ptr<const Uptane::Targets>& image_targets) const;
 
  private:
   void resetMeta();

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -288,6 +288,8 @@ class Targets : public MetaWithKeys {
     terminating_role_.clear();
   }
 
+  // Only makes sense for Targets from the Director repo; the Image repo doesn't
+  // specify ECU serials.
   std::vector<Uptane::Target> getTargets(const Uptane::EcuSerial &ecu_id,
                                          const Uptane::HardwareIdentifier &hw_id) const {
     std::vector<Uptane::Target> result;

--- a/src/libaktualizr/utilities/types.cc
+++ b/src/libaktualizr/utilities/types.cc
@@ -23,6 +23,12 @@ std::ostream &operator<<(std::ostream &os, const StorageType stype) {
   return os;
 }
 
+std::ostream &operator<<(std::ostream &os, VerificationType vtype) {
+  const std::string type_s = Uptane::VerificationTypeToString(vtype);
+  os << '"' << type_s << '"';
+  return os;
+}
+
 std::string TimeToString(struct tm time) {
   std::array<char, 22> formatted{};
   strftime(formatted.data(), 22, "%Y-%m-%dT%H:%M:%SZ", &time);
@@ -134,9 +140,9 @@ std::ostream &operator<<(std::ostream &os, const ResultCode &result_code) {
 
 }  // namespace data
 
-// vim: set tabstop=2 shiftwidth=2 expandtab:
-
 boost::filesystem::path utils::BasedPath::get(const boost::filesystem::path &base) const {
   // note: BasedPath(bp.get() == bp)
   return Utils::absolutePath(base, p_);
 }
+
+// vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,12 +189,9 @@ add_test(NAME test_log_negative
 set_tests_properties(test_log_negative
                      PROPERTIES PASS_REGULAR_EXPRESSION "Invalid log level")
 
-if (BUILD_OSTREE)
-    set(TEST_IPSEC_ARGS "--ostree")
-endif ()
 add_test(NAME test_ip_secondary
          COMMAND ${PROJECT_SOURCE_DIR}/tests/ipsecondary_test.py
-         --build-dir ${PROJECT_BINARY_DIR} --src-dir ${PROJECT_SOURCE_DIR} ${TEST_IPSEC_ARGS})
+         --build-dir ${PROJECT_BINARY_DIR} --src-dir ${PROJECT_SOURCE_DIR})
 set_tests_properties(test_ip_secondary PROPERTIES LABELS "noptest")
 
 add_test(NAME test_director_failure
@@ -213,6 +210,11 @@ add_test(NAME test_customrepo_failure
 set_tests_properties(test_customrepo_failure PROPERTIES LABELS "noptest")
 
 if(BUILD_OSTREE)
+    add_test(NAME test_ip_secondary_ostree
+             COMMAND ${PROJECT_SOURCE_DIR}/tests/ipsecondary_ostree_test.py
+             --build-dir ${PROJECT_BINARY_DIR} --src-dir ${PROJECT_SOURCE_DIR})
+    set_tests_properties(test_ip_secondary_ostree PROPERTIES LABELS "noptest")
+
     add_test(NAME test_treehub_failure
              COMMAND ${PROJECT_SOURCE_DIR}/tests/test_treehub_failure.py
              --build-dir ${PROJECT_BINARY_DIR} --src-dir ${PROJECT_SOURCE_DIR})

--- a/tests/config/aktualizr_secondary.toml
+++ b/tests/config/aktualizr_secondary.toml
@@ -6,3 +6,6 @@ os = "testos"
 sysroot = "testsysroot"
 ostree_server = "test_server"
 packages_file = "/test_packages"
+
+[uptane]
+verification_type = "Full"

--- a/tests/ipsecondary_ostree_test.py
+++ b/tests/ipsecondary_ostree_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import time
+
+from os import getcwd, chdir, path
+
+from test_fixtures import with_aktualizr, with_uptane_backend, KeyStore, with_secondary, with_treehub,\
+    with_sysroot, with_director, TestRunner, IPSecondary
+
+logger = logging.getLogger("IPSecondaryOstreeTest")
+
+
+@with_treehub()
+@with_uptane_backend()
+@with_director()
+@with_sysroot()
+@with_secondary(start=False, output_logs=True)
+@with_aktualizr(start=False, run_mode='once', output_logs=True)
+def test_secondary_ostree_update(uptane_repo, secondary, aktualizr, treehub, sysroot, director, **kwargs):
+    """Test Secondary OSTree update if a boot order of Secondary and Primary is undefined"""
+
+    target_rev = treehub.revision
+    expected_targetname = uptane_repo.add_ostree_target(secondary.id, target_rev, "GARAGE_TARGET_NAME")
+
+    with secondary:
+        with aktualizr:
+            aktualizr.wait_for_completion()
+
+    pending_rev = aktualizr.get_current_pending_image_info(secondary.id)
+
+    if pending_rev != target_rev:
+        logger.error("Pending version {} != the target one {}".format(pending_rev, target_rev))
+        return False
+
+    sysroot.update_revision(pending_rev)
+    secondary.emulate_reboot()
+
+    aktualizr.set_mode('full')
+    with aktualizr:
+        with secondary:
+            director.wait_for_install()
+
+    if not director.get_install_result():
+        logger.error("Installation result is not successful")
+        return False
+
+    installed_rev = aktualizr.get_current_image_info(secondary.id)
+
+    if installed_rev != target_rev:
+        logger.error("Installed version {} != the target one {}".format(installed_rev, target_rev))
+        return False
+
+    if expected_targetname != director.get_ecu_manifest_filepath(secondary.id[1]):
+        logger.error(
+            "Target name doesn't match a filepath value of the reported manifest: expected: {}, actual: {}".
+            format(expected_targetname, director.get_ecu_manifest_filepath(secondary.id[1])))
+        return False
+
+    return True
+
+
+@with_treehub()
+@with_uptane_backend()
+@with_director()
+@with_sysroot()
+@with_secondary(start=False, output_logs=False, force_reboot=True)
+@with_aktualizr(start=False, run_mode='once', output_logs=True)
+def test_secondary_ostree_reboot(uptane_repo, secondary, aktualizr, treehub, sysroot, director, **kwargs):
+    """Test Secondary OSTree update with automatic (forced) reboot"""
+    target_rev = treehub.revision
+    uptane_repo.add_ostree_target(secondary.id, target_rev, "GARAGE_TARGET_NAME")
+
+    with secondary:
+        with aktualizr:
+            aktualizr.wait_for_completion()
+        secondary.wait_for_completion()
+
+    pending_rev = aktualizr.get_current_pending_image_info(secondary.id)
+
+    if pending_rev != target_rev:
+        logger.error("Pending version {} != the target one {}".format(pending_rev, target_rev))
+        return False
+
+    sysroot.update_revision(pending_rev)
+
+    aktualizr.set_mode('full')
+    with aktualizr:
+        with secondary:
+            director.wait_for_install()
+
+    if not director.get_install_result():
+        logger.error("Installation result is not successful")
+        return False
+
+    installed_rev = aktualizr.get_current_image_info(secondary.id)
+
+    if installed_rev != target_rev:
+        logger.error("Installed version {} != the target one {}".format(installed_rev, target_rev))
+        return False
+
+    return True
+
+
+# test suit runner
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser(description='Test IP Secondary with OSTree')
+    parser.add_argument('-b', '--build-dir', help='build directory', default='build')
+    parser.add_argument('-s', '--src-dir', help='source directory', default='.')
+
+    input_params = parser.parse_args()
+
+    KeyStore.base_dir = path.abspath(input_params.src_dir)
+    initial_cwd = getcwd()
+    chdir(input_params.build_dir)
+
+    test_suite = [
+        test_secondary_ostree_update,
+        test_secondary_ostree_reboot,
+    ]
+
+    with TestRunner(test_suite) as runner:
+        test_suite_run_result = runner.run()
+
+    chdir(initial_cwd)
+    exit(0 if test_suite_run_result else 1)

--- a/tests/ipsecondary_test.py
+++ b/tests/ipsecondary_test.py
@@ -61,7 +61,7 @@ def test_secondary_update_if_primary_starts_first(uptane_repo, secondary, aktual
 @with_secondary(start=False, output_logs=True)
 @with_aktualizr(start=False, output_logs=True)
 def test_secondary_update(uptane_repo, secondary, aktualizr, director, **kwargs):
-    '''Test Secondary update if a boot order of Secondary and Primary is undefined'''
+    '''Test Secondary update if the boot order of Secondary and Primary is undefined'''
 
     # add a new image to the repo in order to update the Secondary with it
     secondary_image_filename = "secondary_image_filename.img"
@@ -314,6 +314,7 @@ def test_secondary_ostree_update(uptane_repo, secondary, aktualizr, treehub, sys
 @with_secondary(start=False, output_logs=False, force_reboot=True)
 @with_aktualizr(start=False, run_mode='once', output_logs=True)
 def test_secondary_ostree_reboot(uptane_repo, secondary, aktualizr, treehub, sysroot, director, **kwargs):
+    """Test Secondary OSTree update with automatic (forced) reboot"""
     target_rev = treehub.revision
     uptane_repo.add_ostree_target(secondary.id, target_rev, "GARAGE_TARGET_NAME")
 
@@ -353,7 +354,7 @@ def test_secondary_ostree_reboot(uptane_repo, secondary, aktualizr, treehub, sys
 @with_secondary(start=False)
 @with_aktualizr(start=False, secondary_wait_sec=1, output_logs=False)
 def test_secondary_install_timeout(uptane_repo, secondary, aktualizr, director, **kwargs):
-    '''Test that secondary install fails after a timeout if the secondary never connects'''
+    '''Test that Secondary install fails after a timeout if the Secondary never connects'''
 
     # run aktualizr and secondary and wait until the device/aktualizr is registered
     with aktualizr, secondary:
@@ -438,7 +439,7 @@ def test_primary_wait_secondary_install(uptane_repo, secondary, aktualizr, direc
 @with_secondary(start=False, output_logs=False)
 @with_aktualizr(start=False, output_logs=False)
 def test_primary_timeout_after_device_is_registered(uptane_repo, secondary, aktualizr, **kwargs):
-    '''Test Aktualizr's timeout of waiting for Secondaries after the device/aktualizr was registered at the backend'''
+    '''Test Aktualizr's timeout of waiting for Secondaries after the device was registered with the backend'''
 
     # run aktualizr and Secondary and wait until the device/aktualizr is registered
     with aktualizr, secondary:
@@ -516,9 +517,9 @@ if __name__ == '__main__':
     chdir(input_params.build_dir)
 
     test_suite = [
-                    test_secondary_update,
                     test_secondary_update_if_secondary_starts_first,
                     test_secondary_update_if_primary_starts_first,
+                    test_secondary_update,
                     test_add_secondary,
                     test_remove_secondary,
                     test_replace_secondary,
@@ -526,6 +527,7 @@ if __name__ == '__main__':
                     test_change_secondary_port,
                     test_secondary_install_timeout,
                     test_primary_timeout_during_first_run,
+                    test_primary_wait_secondary_install,
                     test_primary_timeout_after_device_is_registered,
                     test_primary_multiple_secondaries,
     ]

--- a/tests/ipsecondary_test.py
+++ b/tests/ipsecondary_test.py
@@ -12,7 +12,6 @@ from test_fixtures import with_aktualizr, with_uptane_backend, KeyStore, with_se
 logger = logging.getLogger("IPSecondaryTest")
 
 
-# The following is a test suit intended for IP Secondary integration testing
 @with_uptane_backend()
 @with_secondary(start=True)
 @with_aktualizr(start=False, output_logs=False)
@@ -327,97 +326,6 @@ def test_change_secondary_port(uptane_repo, secondary, aktualizr, **kwargs):
     return True
 
 
-@with_treehub()
-@with_uptane_backend()
-@with_director()
-@with_sysroot()
-@with_secondary(start=False, output_logs=True)
-@with_aktualizr(start=False, run_mode='once', output_logs=True)
-def test_secondary_ostree_update(uptane_repo, secondary, aktualizr, treehub, sysroot, director, **kwargs):
-    """Test Secondary OSTree update if a boot order of Secondary and Primary is undefined"""
-
-    target_rev = treehub.revision
-    expected_targetname = uptane_repo.add_ostree_target(secondary.id, target_rev, "GARAGE_TARGET_NAME")
-
-    with secondary:
-        with aktualizr:
-            aktualizr.wait_for_completion()
-
-    pending_rev = aktualizr.get_current_pending_image_info(secondary.id)
-
-    if pending_rev != target_rev:
-        logger.error("Pending version {} != the target one {}".format(pending_rev, target_rev))
-        return False
-
-    sysroot.update_revision(pending_rev)
-    secondary.emulate_reboot()
-
-    aktualizr.set_mode('full')
-    with aktualizr:
-        with secondary:
-            director.wait_for_install()
-
-    if not director.get_install_result():
-        logger.error("Installation result is not successful")
-        return False
-
-    installed_rev = aktualizr.get_current_image_info(secondary.id)
-
-    if installed_rev != target_rev:
-        logger.error("Installed version {} != the target one {}".format(installed_rev, target_rev))
-        return False
-
-    if expected_targetname != director.get_ecu_manifest_filepath(secondary.id[1]):
-        logger.error(
-            "Target name doesn't match a filepath value of the reported manifest: expected: {}, actual: {}".
-            format(expected_targetname, director.get_ecu_manifest_filepath(secondary.id[1])))
-        return False
-
-    return True
-
-
-@with_treehub()
-@with_uptane_backend()
-@with_director()
-@with_sysroot()
-@with_secondary(start=False, output_logs=False, force_reboot=True)
-@with_aktualizr(start=False, run_mode='once', output_logs=True)
-def test_secondary_ostree_reboot(uptane_repo, secondary, aktualizr, treehub, sysroot, director, **kwargs):
-    """Test Secondary OSTree update with automatic (forced) reboot"""
-    target_rev = treehub.revision
-    uptane_repo.add_ostree_target(secondary.id, target_rev, "GARAGE_TARGET_NAME")
-
-    with secondary:
-        with aktualizr:
-            aktualizr.wait_for_completion()
-        secondary.wait_for_completion()
-
-    pending_rev = aktualizr.get_current_pending_image_info(secondary.id)
-
-    if pending_rev != target_rev:
-        logger.error("Pending version {} != the target one {}".format(pending_rev, target_rev))
-        return False
-
-    sysroot.update_revision(pending_rev)
-
-    aktualizr.set_mode('full')
-    with aktualizr:
-        with secondary:
-            director.wait_for_install()
-
-    if not director.get_install_result():
-        logger.error("Installation result is not successful")
-        return False
-
-    installed_rev = aktualizr.get_current_image_info(secondary.id)
-
-    if installed_rev != target_rev:
-        logger.error("Installed version {} != the target one {}".format(installed_rev, target_rev))
-        return False
-
-    return True
-
-
 @with_uptane_backend()
 @with_director()
 @with_secondary(start=False)
@@ -630,7 +538,6 @@ def test_primary_multiple_secondaries_mixed(uptane_repo, secondary, secondary2, 
     return True
 
 
-
 # test suit runner
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
@@ -638,7 +545,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Test IP Secondary')
     parser.add_argument('-b', '--build-dir', help='build directory', default='build')
     parser.add_argument('-s', '--src-dir', help='source directory', default='.')
-    parser.add_argument('-o', '--ostree', help='OSTree support', action='store_true')
 
     input_params = parser.parse_args()
 
@@ -665,12 +571,6 @@ if __name__ == '__main__':
                     test_primary_multiple_secondaries_tuf,
                     test_primary_multiple_secondaries_mixed,
     ]
-
-    if input_params.ostree:
-        test_suite += [
-           test_secondary_ostree_update,
-           test_secondary_ostree_reboot,
-        ]
 
     with TestRunner(test_suite) as runner:
         test_suite_run_result = runner.run()

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -158,7 +158,7 @@ class Aktualizr:
                        check=True, env=self._run_env)
 
     # another ugly stuff that could be replaced with something more reliable if Aktualizr had exposed API
-    # to check status or aktializr-info had output status/info in a structured way (e.g. json)
+    # to check status or aktualizr-info had output status/info in a structured way (e.g. json)
     def get_info(self, retry=30):
         info_exe_res = None
         for ii in range(0, retry):
@@ -172,7 +172,7 @@ class Aktualizr:
         if info_exe_res and info_exe_res.returncode == 0:
             return str(info_exe_res.stdout)
         else:
-            logger.error('Failed to get an aktualizr\'s status info, stdout: {}, stderr: {}'.
+            logger.error('Failed to get aktualizr status info, stdout: {}, stderr: {}'.
                          format(str(info_exe_res.stdout), str(info_exe_res.stderr)))
             return None
 
@@ -198,7 +198,7 @@ class Aktualizr:
     # applicable only to Secondary ECUs due to inconsistency in presenting information
     # about Primary and Secondary ECUs
     # ugly stuff that could be removed if aktualizr had exposed API to check status
-    # or aktializr-info had output status/info in a structured way (e.g. json)
+    # or aktualizr-info had output status/info in a structured way (e.g. json)
     def _get_current_image_info(self, ecu_id, secondary_image_hash_field='installed image hash: '):
         #secondary_image_filename_field = 'installed image filename: '
         aktualizr_status = self.get_info()
@@ -218,7 +218,7 @@ class Aktualizr:
         return hash_val
 
     # ugly stuff that could be removed if Aktualizr had exposed API to check status
-    # or aktializr-info had output status/info in a structured way (e.g. json)
+    # or aktualizr-info had output status/info in a structured way (e.g. json)
     def get_current_primary_image_info(self):
         primary_hash_field = 'Current Primary ECU running version: '
         aktualizr_status = self.get_info()
@@ -231,7 +231,7 @@ class Aktualizr:
             return ""
 
     # ugly stuff that could be removed if Aktualizr had exposed API to check status
-    # or aktializr-info had output status/info in a structured way (e.g. json)
+    # or aktualizr-info had output status/info in a structured way (e.g. json)
     def get_primary_pending_version(self):
         primary_hash_field = 'Pending Primary ECU version: '
         aktualizr_status = self.get_info()


### PR DESCRIPTION
There are plenty of test cases to verify this but I'm still open to feedback. ~~I also still need to work on the Primary side so that it doesn't try to send the Director metadata if it doesn't need to (and/or isn't available) in this case.~~

Update: Primary side works correctly now, too.