### PR TITLE
Ostree non booted

### DIFF
--- a/include/libaktualizr/config.h
+++ b/include/libaktualizr/config.h
@@ -97,8 +97,9 @@ struct PackageConfig {
   boost::filesystem::path images_path{"/var/sota/images"};
   boost::filesystem::path packages_file{"/usr/package.manifest"};
 
-  // Options for simulation (to be used with "none")
+  // Options for simulation
   bool fake_need_reboot{false};
+  BootedType booted{BootedType::kBooted};
 
   // for specialized configuration
   std::map<std::string, std::string> extra;

--- a/include/libaktualizr/types.h
+++ b/include/libaktualizr/types.h
@@ -18,6 +18,9 @@ std::ostream &operator<<(std::ostream &os, ProvisionMode mode);
 enum class StorageType { kFileSystem = 0, kSqlite };
 std::ostream &operator<<(std::ostream &os, StorageType stype);
 
+enum class BootedType { kBooted = 0, kStaged };
+std::ostream &operator<<(std::ostream &os, BootedType btype);
+
 enum class VerificationType {
   kFull = 0,
   kTuf

--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -444,10 +444,11 @@ GObjectUniquePtr<OstreeSysroot> OstreeManager::LoadSysroot(const boost::filesyst
   }
   GError *error = nullptr;
   if (ostree_sysroot_load(sysroot.get(), nullptr, &error) == 0) {
+    const std::string msg = error->message;
     if (error != nullptr) {
       g_error_free(error);
     }
-    throw std::runtime_error("could not load sysroot");
+    throw std::runtime_error("could not load sysroot at " + path.string() + ": " + msg);
   }
   return sysroot;
 }

--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -350,12 +350,23 @@ Json::Value OstreeManager::getInstalledPackages() const {
 }
 
 std::string OstreeManager::getCurrentHash() const {
+  OstreeDeployment *deployment = nullptr;
   GObjectUniquePtr<OstreeSysroot> sysroot_smart = OstreeManager::LoadSysroot(config.sysroot);
-  OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
-  if (booted_deployment == nullptr) {
-    throw std::runtime_error("Could not get booted deployment in " + config.sysroot.string());
+  if (config.booted == BootedType::kBooted) {
+    deployment = ostree_sysroot_get_booted_deployment(sysroot_smart.get());
+  } else {
+    g_autoptr(GPtrArray) deployments = ostree_sysroot_get_deployments(sysroot_smart.get());
+    if (deployments != nullptr && deployments->len > 0) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      deployment = static_cast<OstreeDeployment *>(deployments->pdata[0]);
+    }
   }
-  return ostree_deployment_get_csum(booted_deployment);
+  if (deployment == nullptr) {
+    std::stringstream text;
+    text << "Could not get " << config.booted << " deployment in " << config.sysroot.string();
+    throw std::runtime_error(text.str());
+  }
+  return ostree_deployment_get_csum(deployment);
 }
 
 Uptane::Target OstreeManager::getCurrent() const {

--- a/src/libaktualizr/package_manager/ostreemanager.h
+++ b/src/libaktualizr/package_manager/ostreemanager.h
@@ -71,7 +71,6 @@ class OstreeManager : public PackageManagerInterface {
  private:
   TargetStatus verifyTargetInternal(const Uptane::Target &target) const;
 
- private:
   std::unique_ptr<Bootloader> bootloader_;
 };
 

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -22,6 +22,8 @@ void PackageConfig::updateFromPropertyTree(const boost::property_tree::ptree& pt
       CopyFromConfig(packages_file, cp.first, pt);
     } else if (cp.first == "fake_need_reboot") {
       CopyFromConfig(fake_need_reboot, cp.first, pt);
+    } else if (cp.first == "booted") {
+      CopyFromConfig(booted, cp.first, pt);
     } else {
       extra[cp.first] = Utils::stripQuotes(cp.second.get_value<std::string>());
     }
@@ -36,6 +38,7 @@ void PackageConfig::writeToStream(std::ostream& out_stream) const {
   writeOption(out_stream, images_path, "images_path");
   writeOption(out_stream, packages_file, "packages_file");
   writeOption(out_stream, fake_need_reboot, "fake_need_reboot");
+  writeOption(out_stream, booted, "booted");
 
   // note that this is imperfect as it will not print default values deduced
   // from users of `extra`

--- a/src/libaktualizr/utilities/config_utils.h
+++ b/src/libaktualizr/utilities/config_utils.h
@@ -76,6 +76,20 @@ inline void CopyFromConfig(StorageType& dest, const std::string& option_name, co
 }
 
 template <>
+inline void CopyFromConfig(BootedType& dest, const std::string& option_name, const boost::property_tree::ptree& pt) {
+  boost::optional<std::string> value = pt.get_optional<std::string>(option_name);
+  if (value.is_initialized()) {
+    std::string storage_type{StripQuotesFromStrings(value.get())};
+    // "0" is for backwards compatibility with aktualizr-lite usage.
+    if (storage_type == "staged" || storage_type == "0") {
+      dest = BootedType::kStaged;
+    } else {
+      dest = BootedType::kBooted;
+    }
+  }
+}
+
+template <>
 inline void CopyFromConfig(KeyType& dest, const std::string& option_name, const boost::property_tree::ptree& pt) {
   boost::optional<std::string> value = pt.get_optional<std::string>(option_name);
   if (value.is_initialized()) {

--- a/src/libaktualizr/utilities/types.cc
+++ b/src/libaktualizr/utilities/types.cc
@@ -33,6 +33,20 @@ std::ostream &Uptane::operator<<(std::ostream &os, const EcuSerial &ecu_serial) 
   return os;
 }
 
+std::ostream &operator<<(std::ostream &os, const BootedType btype) {
+  std::string btype_str;
+  switch (btype) {
+    case BootedType::kStaged:
+      btype_str = "staged";
+      break;
+    default:
+      btype_str = "booted";
+      break;
+  }
+  os << '"' << btype_str << '"';
+  return os;
+}
+
 std::ostream &operator<<(std::ostream &os, VerificationType vtype) {
   const std::string type_s = Uptane::VerificationTypeToString(vtype);
   os << '"' << type_s << '"';


### PR DESCRIPTION
FYI @mike-sul. This works with practical testing but the tests don't work if I remove the mocking logic. (See https://github.com/uptane/aktualizr/tree/ostree-non-booted-wip for a draft of what I mean.) The Secondary fails to install with `ostree_sysroot_deploy_tree: Failed to find kernel in /usr/lib/modules, /usr/lib/ostree-boot or /boot`. I think this comes from the fact that we are creating a commit without any real content, and those directories in the deployed root are indeed empty. I tried populating at least the first one with fake objects but that didn't do the trick. How did you solve this problem for the aktualizr-lite tests?