### PR TITLE
Explictly use python3 in tests

### DIFF
--- a/tests/run_expired_test.sh
+++ b/tests/run_expired_test.sh
@@ -7,7 +7,7 @@ TEMP_DIR=/tmp/temp_aktualizr_expire_repo/$(mktemp -d)/$1
 
 cp ./tests/test_data/credentials.zip $TEMP_DIR
 
-PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
 TREEHUB="{\
   \"oauth2\": {
     \"server\": \"http://localhost:$PORT\",\

--- a/tests/sota_tools/test-garage-deploy-dry-run
+++ b/tests/sota_tools/test-garage-deploy-dry-run
@@ -4,7 +4,7 @@ trap 'kill %1' EXIT
 
 TEMP_DIR=$(mktemp -d)
 
-PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
 TREEHUB="{\
   \"ostree\": {\
     \"server\": \"http://localhost:$PORT/\"\

--- a/tests/sota_tools/test-garage-deploy-offline-signing
+++ b/tests/sota_tools/test-garage-deploy-offline-signing
@@ -4,7 +4,7 @@ trap 'kill %1' EXIT
 
 TEMP_DIR=$(mktemp -d)
 
-PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
 TREEHUB="{\
   \"ostree\": {\
     \"server\": \"http://localhost:$PORT/\"\

--- a/tests/sota_tools/test-garage-deploy-online-signing
+++ b/tests/sota_tools/test-garage-deploy-online-signing
@@ -4,7 +4,7 @@ trap 'kill %1' EXIT
 
 TEMP_DIR=$(mktemp -d)
 
-PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
 TREEHUB="{\
   \"ostree\": {\
     \"server\": \"http://localhost:$PORT/\"\

--- a/tests/sota_tools/test-garage-deploy-upload-failed
+++ b/tests/sota_tools/test-garage-deploy-upload-failed
@@ -4,7 +4,7 @@ trap 'kill %1' EXIT
 
 TEMP_DIR=$(mktemp -d)
 
-PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
 TREEHUB="{\
   \"ostree\": {\
     \"server\": \"http://localhost:$PORT/\"\

--- a/tests/sota_tools/test-missing-commit
+++ b/tests/sota_tools/test-missing-commit
@@ -4,7 +4,7 @@ trap 'kill %1' EXIT
 
 TEMP_DIR=$(mktemp -d)
 
-PORT=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
 TREEHUB="{\
   \"ostree\": {\
     \"server\": \"http://localhost:$PORT/\"\


### PR DESCRIPTION
Debian 11 has 'python2' and 'python3' but no 'python' binary. Explicitly use
python3 in a few tests. Without these I was getting test failures.

Signed-off-by: Phil Wise <phil@phil-wise.com>