### PR TITLE
Reduce size of SotaUptaneClient's public interface

### DIFF
--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -1482,3 +1482,12 @@ boost::optional<Uptane::HardwareIdentifier> SotaUptaneClient::getEcuHwId(const U
 
   return boost::none;
 }
+
+std::ifstream SotaUptaneClient::openStoredTarget(const Uptane::Target &target) {
+  auto status = package_manager_->verifyTarget(target);
+  if (status == TargetStatus::kGood) {
+    return package_manager_->openTargetFile(target);
+  } else {
+    throw std::runtime_error("Failed to open Target");
+  }
+}


### PR DESCRIPTION
I went through and found all the currently public member functions of
SotaUptaneClient that are only called by test code and made them private and
visible to the test using FRIEND_TEST. The idea here is to have a more
manageable public interface to make refactoring simpler.

Signed-off-by: Phil Wise <phil@phil-wise.com>