### PR TITLE
Fix a URL to the tuf test vectors sub-module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tests/tuf-test-vectors"]
 	path = tests/tuf-test-vectors
-	url = https://github.com/advancedtelematic/tuf-test-vectors/
+	url = https://github.com/advancedtelematic/tuf-test-vectors.git
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git


### PR DESCRIPTION
Add suffix `.git` to the submodule URL.

Signed-off-by: Mike Sul <mike.sul@foundries.io>