### PR TITLE
Unify on ToString.

### DIFF
--- a/include/libaktualizr/types.h
+++ b/include/libaktualizr/types.h
@@ -250,7 +250,7 @@ struct ResultCode {
   ResultCode(ResultCode::Numeric in_num_code, std::string text_code_in)
       : num_code(in_num_code), text_code(std::move(text_code_in)) {}
 
-  bool operator==(const ResultCode &rhs) const { return num_code == rhs.num_code && toString() == rhs.toString(); }
+  bool operator==(const ResultCode &rhs) const { return num_code == rhs.num_code && ToString() == rhs.ToString(); }
   bool operator!=(const ResultCode &rhs) const { return !(*this == rhs); }
   friend std::ostream &operator<<(std::ostream &os, const ResultCode &result_code);
 
@@ -261,7 +261,7 @@ struct ResultCode {
   // any string representation. This is specifically useful for campaign success
   // analysis, because the device installation report concatenates the
   // individual ECU ResultCodes.
-  std::string toString() const {
+  std::string ToString() const {
     if (text_code != "") {
       return text_code;
     }

--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -310,7 +310,7 @@ void AktualizrSecondary::copyMetadata(Uptane::MetaBundle& meta_bundle, const Upt
                                       const Uptane::Role& role, std::string& json) {
   auto key = std::make_pair(repo, role);
   if (meta_bundle.count(key) > 0) {
-    LOG_WARNING << repo.toString() << " metadata in contains multiple " << role.ToString() << " objects.";
+    LOG_WARNING << repo << " metadata in contains multiple " << role << " objects.";
     return;
   }
   meta_bundle.emplace(key, std::move(json));

--- a/src/aktualizr_secondary/aktualizr_secondary_ostree.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_ostree.cc
@@ -43,7 +43,7 @@ void AktualizrSecondaryOstree::initialize() {
           AktualizrSecondary::storage()->saveInstalledVersion(serial().ToString(), *pending_target,
                                                               InstalledVersionUpdateMode::kCurrent);
         } else {
-          LOG_ERROR << "Application of the pending update has failed: (" << install_res.result_code.toString() << ")"
+          LOG_ERROR << "Application of the pending update has failed: (" << install_res.result_code.ToString() << ")"
                     << install_res.description;
           AktualizrSecondary::storage()->saveInstalledVersion(serial().ToString(), *pending_target,
                                                               InstalledVersionUpdateMode::kNone);

--- a/src/aktualizr_secondary/secondary_tcp_server.cc
+++ b/src/aktualizr_secondary/secondary_tcp_server.cc
@@ -33,7 +33,7 @@ void SecondaryTcpServer::run() {
   if (listen(*listen_socket_, SOMAXCONN) < 0) {
     throw std::system_error(errno, std::system_category(), "listen");
   }
-  LOG_INFO << "Secondary TCP server listening on " << listen_socket_.toString();
+  LOG_INFO << "Secondary TCP server listening on " << listen_socket_.ToString();
 
   {
     std::unique_lock<std::mutex> lock(running_condition_mutex_);

--- a/src/aktualizr_secondary/update_agent_ostree.cc
+++ b/src/aktualizr_secondary/update_agent_ostree.cc
@@ -85,7 +85,7 @@ data::InstallationResult OstreeUpdateAgent::downloadTargetRev(const Uptane::Targ
     }
     default: {
       LOG_ERROR << "Failed to download the target commit: " << target.sha256Hash() << " ( "
-                << result.result_code.toString() << " ): " << result.description;
+                << result.result_code.ToString() << " ): " << result.description;
     }
   }
 

--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -89,7 +89,6 @@ add_aktualizr_test(NAME target_mismatch
 add_aktualizr_test(NAME metadata_fetch
                    SOURCES metadata_fetch_test.cc
                    PROJECT_WORKING_DIRECTORY
-                   ARGS "$<TARGET_FILE:uptane-generator>"
                    LIBRARIES uptane_generator_lib virtual_secondary)
 
 add_aktualizr_test(NAME metadata_expiration

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -2082,7 +2082,7 @@ TEST(Aktualizr, ManifestCustom) {
 
 TEST(Aktualizr, CustomInstallationRawReport) {
   TemporaryDirectory temp_dir;
-  auto http = std::make_shared<HttpFake>(temp_dir.Path(), "hasupdate", fake_meta_dir);
+  auto http = std::make_shared<HttpFake>(temp_dir.Path(), "hasupdates", fake_meta_dir);
 
   Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
   auto storage = INvStorage::newStorage(conf.storage);

--- a/src/libaktualizr/primary/metadata_fetch_test.cc
+++ b/src/libaktualizr/primary/metadata_fetch_test.cc
@@ -5,9 +5,8 @@
 #include "httpfake.h"
 #include "libaktualizr/aktualizr.h"
 #include "test_utils.h"
+#include "uptane_repo.h"
 #include "uptane_test_common.h"
-
-boost::filesystem::path uptane_generator_path;
 
 class HttpFakeMetaCounter : public HttpFake {
  public:
@@ -70,8 +69,8 @@ TEST(Aktualizr, MetadataFetch) {
   aktualizr.Initialize();
 
   // No updates scheduled: only download Director Root and Targets metadata.
-  Process uptane_gen(uptane_generator_path.string());
-  uptane_gen.run({"generate", "--path", meta_dir.PathString()});
+  UptaneRepo uptane_repo_{meta_dir.PathString(), "", ""};
+  uptane_repo_.generateRepo(KeyType::kED25519);
 
   result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
   EXPECT_EQ(update_result.status, result::UpdateStatus::kNoUpdatesAvailable);
@@ -86,14 +85,12 @@ TEST(Aktualizr, MetadataFetch) {
 
   // Two images added, but only one update scheduled: all metadata objects
   // should be fetched once.
-  uptane_gen.run({"image", "--path", meta_dir.PathString(), "--filename", "tests/test_data/firmware.txt",
-                  "--targetname", "firmware.txt", "--hwid", "primary_hw"});
-  uptane_gen.run({"image", "--path", meta_dir.PathString(), "--filename", "tests/test_data/firmware_name.txt",
-                  "--targetname", "firmware_name.txt", "--hwid", "primary_hw"});
-  uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
-                  "--serial", "CA:FE:A6:D2:84:9D"});
-  uptane_gen.run({"adddelegation", "--path", meta_dir.PathString(), "--dname", "role-abc", "--dpattern", "abc/*"});
-  uptane_gen.run({"signtargets", "--path", meta_dir.PathString()});
+  uptane_repo_.addImage("tests/test_data/firmware.txt", "firmware.txt", "primary_hw", "", Delegation());
+  uptane_repo_.addImage("tests/test_data/firmware_name.txt", "firmware_name.txt", "primary_hw", "", Delegation());
+  uptane_repo_.addTarget("firmware.txt", "primary_hw", "CA:FE:A6:D2:84:9D", "");
+  uptane_repo_.addDelegation(Uptane::Role("role-abc", true), Uptane::Role("targets", false), "abc/*", false,
+                             KeyType::kED25519);
+  uptane_repo_.signTargets();
 
   update_result = aktualizr.CheckUpdates().get();
   EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
@@ -108,10 +105,9 @@ TEST(Aktualizr, MetadataFetch) {
 
   // Update scheduled with pre-existing image: no need to refetch Image repo
   // Snapshot or Targets metadata.
-  uptane_gen.run({"emptytargets", "--path", meta_dir.PathString()});
-  uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware_name.txt", "--hwid",
-                  "primary_hw", "--serial", "CA:FE:A6:D2:84:9D"});
-  uptane_gen.run({"signtargets", "--path", meta_dir.PathString()});
+  uptane_repo_.emptyTargets();
+  uptane_repo_.addTarget("firmware_name.txt", "primary_hw", "CA:FE:A6:D2:84:9D", "");
+  uptane_repo_.signTargets();
 
   update_result = aktualizr.CheckUpdates().get();
   EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
@@ -126,12 +122,11 @@ TEST(Aktualizr, MetadataFetch) {
 
   // Delegation added to an existing delegation; update scheduled with
   // pre-existing image: Snapshot must be refetched, but Targets are unchanged.
-  uptane_gen.run({"emptytargets", "--path", meta_dir.PathString()});
-  uptane_gen.run({"addtarget", "--path", meta_dir.PathString(), "--targetname", "firmware.txt", "--hwid", "primary_hw",
-                  "--serial", "CA:FE:A6:D2:84:9D"});
-  uptane_gen.run({"adddelegation", "--path", meta_dir.PathString(), "--dname", "role-def", "--dpattern", "def/*",
-                  "--dparent", "role-abc"});
-  uptane_gen.run({"signtargets", "--path", meta_dir.PathString()});
+  uptane_repo_.emptyTargets();
+  uptane_repo_.addTarget("firmware.txt", "primary_hw", "CA:FE:A6:D2:84:9D", "");
+  uptane_repo_.addDelegation(Uptane::Role("role-def", true), Uptane::Role("role-abc", true), "def/*", false,
+                             KeyType::kED25519);
+  uptane_repo_.signTargets();
 
   update_result = aktualizr.CheckUpdates().get();
   EXPECT_EQ(update_result.status, result::UpdateStatus::kUpdatesAvailable);
@@ -148,11 +143,6 @@ TEST(Aktualizr, MetadataFetch) {
 #ifndef __NO_MAIN__
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  if (argc != 2) {
-    std::cerr << "Error: " << argv[0] << " requires the path to the uptane-generator utility\n";
-    return EXIT_FAILURE;
-  }
-  uptane_generator_path = argv[1];
 
   logger_init();
   logger_set_threshold(boost::log::trivial::trace);

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -486,7 +486,7 @@ void SotaUptaneClient::computeDeviceInstallationResult(data::InstallationResult 
       // format:
       // ecu1_hwid:failure1|ecu2_hwid:failure2
       if (!installation_res.isSuccess()) {
-        const std::string ecu_code_str = (*hw_id).ToString() + ":" + installation_res.result_code.toString();
+        const std::string ecu_code_str = (*hw_id).ToString() + ":" + installation_res.result_code.ToString();
         result_code_err_str += (!result_code_err_str.empty() ? "|" : "") + ecu_code_str;
       }
     }
@@ -533,23 +533,23 @@ void SotaUptaneClient::getNewTargets(std::vector<Uptane::Target> *new_targets, u
         // This is triggered if a Secondary is removed after an update was
         // installed on it because of the empty targets optimization.
         // Thankfully if the Director issues new Targets, it fixes itself.
-        LOG_ERROR << "Unknown ECU ID in Director Targets metadata: " << ecu_serial.ToString();
+        LOG_ERROR << "Unknown ECU ID in Director Targets metadata: " << ecu_serial;
         throw Uptane::BadEcuId(target.filename());
       }
 
       if (*hw_id_known != hw_id) {
-        LOG_ERROR << "Wrong hardware identifier for ECU " << ecu_serial.ToString();
+        LOG_ERROR << "Wrong hardware identifier for ECU " << ecu_serial;
         throw Uptane::BadHardwareId(target.filename());
       }
 
       boost::optional<Uptane::Target> current_version;
       if (!storage->loadInstalledVersions(ecu_serial.ToString(), &current_version, nullptr)) {
-        LOG_WARNING << "Could not load currently installed version for ECU ID: " << ecu_serial.ToString();
+        LOG_WARNING << "Could not load currently installed version for ECU ID: " << ecu_serial;
         break;
       }
 
       if (!current_version) {
-        LOG_WARNING << "Current version for ECU ID: " << ecu_serial.ToString() << " is unknown";
+        LOG_WARNING << "Current version for ECU ID: " << ecu_serial << " is unknown";
         is_new = true;
       } else if (current_version->MatchTarget(target)) {
         // Do nothing; target is already installed.
@@ -1313,7 +1313,7 @@ void SotaUptaneClient::sendMetadataToEcus(const std::vector<Uptane::Target> &tar
       if (!local_result.isSuccess()) {
         LOG_ERROR << "Sending metadata to " << sec->first << " failed: " << local_result.result_code << " "
                   << local_result.description;
-        const std::string ecu_code_str = hw_id.ToString() + ":" + local_result.result_code.toString();
+        const std::string ecu_code_str = hw_id.ToString() + ":" + local_result.result_code.ToString();
         result_code_err_str += (!result_code_err_str.empty() ? "|" : "") + ecu_code_str;
       }
     }

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -26,14 +26,14 @@ void SQLStorage::cleanMetaVersion(Uptane::RepositoryType repo, const Uptane::Rol
     // Nothing to do here. The log message that used to be here was confusing.
     return;
   } else if (result != SQLITE_ROW) {
-    LOG_ERROR << "Failed to get " << repo.toString() << " " << role.ToString() << " metadata: " << db.errmsg();
+    LOG_ERROR << "Failed to get " << repo << " " << role << " metadata: " << db.errmsg();
     return;
   }
   const std::string meta = std::string(reinterpret_cast<const char*>(sqlite3_column_blob(statement.get(), 0)));
 
   const int version = Uptane::extractVersionUntrusted(meta);
   if (version < 0) {
-    LOG_ERROR << "Corrupted " << repo.toString() << " " << role.ToString() << " metadata.";
+    LOG_ERROR << "Corrupted " << repo << " " << role << " metadata.";
     return;
   }
 
@@ -42,7 +42,7 @@ void SQLStorage::cleanMetaVersion(Uptane::RepositoryType repo, const Uptane::Rol
                                                  static_cast<int>(repo), role.ToInt(), version);
 
   if (statement.step() != SQLITE_DONE) {
-    LOG_ERROR << "Failed to clear " << repo.toString() << " " << role.ToString() << " metadata: " << db.errmsg();
+    LOG_ERROR << "Failed to clear " << repo << " " << role << " metadata: " << db.errmsg();
     return;
   }
 
@@ -51,7 +51,7 @@ void SQLStorage::cleanMetaVersion(Uptane::RepositoryType repo, const Uptane::Rol
       role.ToInt(), -1);
 
   if (statement.step() != SQLITE_DONE) {
-    LOG_ERROR << "Failed to update " << repo.toString() << " " << role.ToString() << " metadata: " << db.errmsg();
+    LOG_ERROR << "Failed to update " << repo << " " << role << " metadata: " << db.errmsg();
     return;
   }
 
@@ -541,7 +541,7 @@ void SQLStorage::storeNonRoot(const std::string& data, Uptane::RepositoryType re
                                                      static_cast<int>(repo), role.ToInt());
 
   if (del_statement.step() != SQLITE_DONE) {
-    LOG_ERROR << "Failed to clear " << role.ToString() << " metadata: " << db.errmsg();
+    LOG_ERROR << "Failed to clear " << role << " metadata: " << db.errmsg();
     return;
   }
 
@@ -550,7 +550,7 @@ void SQLStorage::storeNonRoot(const std::string& data, Uptane::RepositoryType re
                                                   static_cast<int>(repo), role.ToInt(), Uptane::Version().version());
 
   if (ins_statement.step() != SQLITE_DONE) {
-    LOG_ERROR << "Failed to add " << role.ToString() << "metadata: " << db.errmsg();
+    LOG_ERROR << "Failed to add " << role << "metadata: " << db.errmsg();
     return;
   }
 
@@ -615,10 +615,10 @@ bool SQLStorage::loadNonRoot(std::string* data, Uptane::RepositoryType repo, con
   int result = statement.step();
 
   if (result == SQLITE_DONE) {
-    LOG_TRACE << role.ToString() << " metadata not found in database";
+    LOG_TRACE << role << " metadata not found in database";
     return false;
   } else if (result != SQLITE_ROW) {
-    LOG_ERROR << "Failed to get " << role.ToString() << " metadata: " << db.errmsg();
+    LOG_ERROR << "Failed to get " << role << " metadata: " << db.errmsg();
     return false;
   }
   if (data != nullptr) {

--- a/src/libaktualizr/uptane/directorrepository.cc
+++ b/src/libaktualizr/uptane/directorrepository.cc
@@ -12,7 +12,7 @@ void DirectorRepository::resetMeta() {
 
 void DirectorRepository::checkTargetsExpired() {
   if (latest_targets.isExpired(TimeStamp::Now())) {
-    throw Uptane::ExpiredMetadata(type.toString(), Role::TARGETS);
+    throw Uptane::ExpiredMetadata(type.ToString(), Role::TARGETS);
   }
 }
 
@@ -20,7 +20,7 @@ void DirectorRepository::targetsSanityCheck() {
   //  5.4.4.6.6. If checking Targets metadata from the Director repository,
   //  verify that there are no delegations.
   if (!latest_targets.delegated_role_names_.empty()) {
-    throw Uptane::InvalidMetadata(type.toString(), Role::TARGETS, "Found unexpected delegation.");
+    throw Uptane::InvalidMetadata(type.ToString(), Role::TARGETS, "Found unexpected delegation.");
   }
   //  5.4.4.6.7. If checking Targets metadata from the Director repository,
   //  check that no ECU identifier is represented more than once.
@@ -31,7 +31,7 @@ void DirectorRepository::targetsSanityCheck() {
         ecu_ids.insert(ecu.first);
       } else {
         LOG_ERROR << "ECU " << ecu.first << " appears twice in Director's Targets";
-        throw Uptane::InvalidMetadata(type.toString(), Role::TARGETS, "Found repeated ECU ID.");
+        throw Uptane::InvalidMetadata(type.ToString(), Role::TARGETS, "Found repeated ECU ID.");
       }
     }
   }

--- a/src/libaktualizr/uptane/fetcher.cc
+++ b/src/libaktualizr/uptane/fetcher.cc
@@ -13,7 +13,7 @@ void Fetcher::fetchRole(std::string* result, int64_t maxsize, RepositoryType rep
   url += "/" + version.RoleFileName(role);
   HttpResponse response = http->get(url, maxsize);
   if (!response.isOk()) {
-    throw Uptane::MetadataFetchFailure(repo.toString(), role.ToString());
+    throw Uptane::MetadataFetchFailure(repo.ToString(), role.ToString());
   }
   *result = response.body;
 }

--- a/src/libaktualizr/uptane/imagerepository.cc
+++ b/src/libaktualizr/uptane/imagerepository.cc
@@ -24,7 +24,7 @@ void ImageRepository::verifyTimestamp(const std::string& timestamp_raw) {
 
 void ImageRepository::checkTimestampExpired() {
   if (timestamp.isExpired(TimeStamp::Now())) {
-    throw Uptane::ExpiredMetadata(type.toString(), Role::TIMESTAMP);
+    throw Uptane::ExpiredMetadata(type.ToString(), Role::TIMESTAMP);
   }
 }
 
@@ -97,7 +97,7 @@ void ImageRepository::verifySnapshot(const std::string& snapshot_raw, bool prefe
 
 void ImageRepository::checkSnapshotExpired() {
   if (snapshot.isExpired(TimeStamp::Now())) {
-    throw Uptane::ExpiredMetadata(type.toString(), Role::SNAPSHOT);
+    throw Uptane::ExpiredMetadata(type.ToString(), Role::SNAPSHOT);
   }
 }
 
@@ -132,7 +132,7 @@ void ImageRepository::verifyRoleHashes(const std::string& role_data, const Uptan
       case Hash::Type::kSha256:
         if (Hash(Hash::Type::kSha256, boost::algorithm::hex(Crypto::sha256digest(canonical))) != it) {
           if (!prefetch) {
-            LOG_ERROR << "Hash verification for " << role.ToString() << " metadata failed";
+            LOG_ERROR << "Hash verification for " << role << " metadata failed";
           }
           throw Uptane::SecurityException(RepositoryType::IMAGE, "Hash metadata mismatch");
         }
@@ -140,7 +140,7 @@ void ImageRepository::verifyRoleHashes(const std::string& role_data, const Uptan
       case Hash::Type::kSha512:
         if (Hash(Hash::Type::kSha512, boost::algorithm::hex(Crypto::sha512digest(canonical))) != it) {
           if (!prefetch) {
-            LOG_ERROR << "Hash verification for " << role.ToString() << " metadata failed";
+            LOG_ERROR << "Hash verification for " << role << " metadata failed";
           }
           throw Uptane::SecurityException(RepositoryType::IMAGE, "Hash metadata mismatch");
         }
@@ -195,7 +195,7 @@ std::shared_ptr<Uptane::Targets> ImageRepository::verifyDelegation(const std::st
 
 void ImageRepository::checkTargetsExpired() {
   if (targets->isExpired(TimeStamp::Now())) {
-    throw Uptane::ExpiredMetadata(type.toString(), Role::TARGETS);
+    throw Uptane::ExpiredMetadata(type.ToString(), Role::TARGETS);
   }
 }
 

--- a/src/libaktualizr/uptane/metawithkeys.cc
+++ b/src/libaktualizr/uptane/metawithkeys.cc
@@ -25,7 +25,7 @@ void Uptane::MetaWithKeys::ParseRole(const RepositoryType repo, const Json::Valu
                                      const std::string &meta_role) {
   if (role == Role::InvalidRole()) {
     LOG_WARNING << "Invalid role in " << meta_role << ".json";
-    LOG_TRACE << "Role name:" << role.ToString();
+    LOG_TRACE << "Role name:" << role;
     return;
   }
   // Threshold
@@ -96,7 +96,7 @@ void Uptane::MetaWithKeys::UnpackSignedObject(const RepositoryType repo, const R
     }
 
     if (keys_for_role_.count(std::make_pair(role, keyid)) == 0U) {
-      LOG_WARNING << "KeyId " << keyid << " is not valid to sign for this role (" << role.ToString() << ").";
+      LOG_WARNING << "KeyId " << keyid << " is not valid to sign for this role (" << role << ").";
       continue;
     }
     const std::string signature = (*sig)["sig"].asString();

--- a/src/libaktualizr/uptane/role.cc
+++ b/src/libaktualizr/uptane/role.cc
@@ -46,6 +46,6 @@ std::string Version::RoleFileName(const Role &role) const {
   if (version_ != Version::ANY_VERSION) {
     ss << version_ << ".";
   }
-  ss << role.ToString() << ".json";
+  ss << role << ".json";
   return ss.str();
 }

--- a/src/libaktualizr/uptane/tuf.cc
+++ b/src/libaktualizr/uptane/tuf.cc
@@ -16,22 +16,17 @@
 using Uptane::Target;
 using Uptane::Version;
 
+std::ostream &Uptane::operator<<(std::ostream &os, const RepositoryType &repo_type) {
+  os << repo_type.ToString();
+  return os;
+}
+
 std::ostream &Uptane::operator<<(std::ostream &os, const Version &v) {
   if (v.version_ == Version::ANY_VERSION) {
     os << "vANY";
   } else {
     os << "v" << v.version_;
   }
-  return os;
-}
-
-std::ostream &Uptane::operator<<(std::ostream &os, const HardwareIdentifier &hwid) {
-  os << hwid.hwid_;
-  return os;
-}
-
-std::ostream &Uptane::operator<<(std::ostream &os, const EcuSerial &ecu_serial) {
-  os << ecu_serial.ecu_serial_;
   return os;
 }
 
@@ -482,7 +477,7 @@ int Uptane::extractVersionUntrusted(const std::string &meta) {
 std::string Uptane::getMetaFromBundle(const MetaBundle &bundle, const RepositoryType repo, const Role &role) {
   auto it = bundle.find(std::make_pair(repo, role));
   if (it == bundle.end()) {
-    throw std::runtime_error("Metadata not found for " + role.ToString() + " role from the " + repo.toString() +
+    throw std::runtime_error("Metadata not found for " + role.ToString() + " role from the " + repo.ToString() +
                              " repository.");
   }
   return it->second;

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -41,9 +41,9 @@ class RepositoryType {
     }
   }
   operator int() const { return static_cast<int>(type_); }
-  operator std::string() const { return toString(); }
+  operator std::string() const { return ToString(); }
   Type type_;
-  std::string toString() const {
+  std::string ToString() const {
     if (type_ == RepositoryType::Type::kDirector) {
       return DIRECTOR;
     } else if (type_ == RepositoryType::Type::kImage) {
@@ -52,7 +52,11 @@ class RepositoryType {
       return "";
     }
   }
+
+  friend std::ostream &operator<<(std::ostream &os, const RepositoryType &repo_type);
 };
+
+std::ostream &operator<<(std::ostream &os, const RepositoryType &repo_type);
 
 using KeyId = std::string;
 /**
@@ -357,7 +361,7 @@ class Snapshot : public BaseMeta {
 
 struct MetaPairHash {
   std::size_t operator()(const std::pair<RepositoryType, Role> &pair) const {
-    return std::hash<std::string>()(pair.first.toString()) ^ std::hash<std::string>()(pair.second.ToString());
+    return std::hash<std::string>()(pair.first.ToString()) ^ std::hash<std::string>()(pair.second.ToString());
   }
 };
 

--- a/src/libaktualizr/uptane/uptanerepository.cc
+++ b/src/libaktualizr/uptane/uptanerepository.cc
@@ -27,7 +27,7 @@ void RepositoryCommon::initRoot(RepositoryType repo_type, const std::string& roo
     root = Root(type, Utils::parseJSON(root_raw));        // initialization and format check
     root = Root(type, Utils::parseJSON(root_raw), root);  // signature verification against itself
   } catch (const std::exception& e) {
-    LOG_ERROR << "Loading initial " << repo_type.toString() << " Root metadata failed: " << e.what();
+    LOG_ERROR << "Loading initial " << repo_type << " Root metadata failed: " << e.what();
     throw;
   }
 }
@@ -47,7 +47,7 @@ void RepositoryCommon::verifyRoot(const std::string& root_raw) {
     if (root.version() != prev_version + 1) {
       LOG_ERROR << "Version " << root.version() << " in Root metadata doesn't match the expected value "
                 << prev_version + 1;
-      throw Uptane::RootRotationError(type.toString());
+      throw Uptane::RootRotationError(type.ToString());
     }
   } catch (const std::exception& e) {
     LOG_ERROR << "Signature verification for Root metadata failed: " << e.what();
@@ -93,7 +93,7 @@ void RepositoryCommon::updateRoot(INvStorage& storage, const IMetadataFetcher& f
   // lower than the expiration timestamp in the latest Root metadata file.
   // (Checks for a freeze attack.)
   if (rootExpired()) {
-    throw Uptane::ExpiredMetadata(repo_type.toString(), Role::ROOT);
+    throw Uptane::ExpiredMetadata(repo_type.ToString(), Role::ROOT);
   }
 }
 

--- a/src/libaktualizr/utilities/types.cc
+++ b/src/libaktualizr/utilities/types.cc
@@ -23,6 +23,16 @@ std::ostream &operator<<(std::ostream &os, const StorageType stype) {
   return os;
 }
 
+std::ostream &Uptane::operator<<(std::ostream &os, const HardwareIdentifier &hwid) {
+  os << hwid.ToString();
+  return os;
+}
+
+std::ostream &Uptane::operator<<(std::ostream &os, const EcuSerial &ecu_serial) {
+  os << ecu_serial.ToString();
+  return os;
+}
+
 std::ostream &operator<<(std::ostream &os, VerificationType vtype) {
   const std::string type_s = Uptane::VerificationTypeToString(vtype);
   os << '"' << type_s << '"';
@@ -92,7 +102,7 @@ const std::map<data::ResultCode::Numeric, const char *> data::ResultCode::string
 };
 
 std::string data::ResultCode::toRepr() const {
-  std::string s = toString();
+  std::string s = ToString();
 
   if (s.find('\"') != std::string::npos) {
     throw std::runtime_error("Result code cannot contain double quotes");
@@ -128,7 +138,7 @@ ResultCode data::ResultCode::fromRepr(const std::string &repr) {
 Json::Value InstallationResult::toJson() const {
   Json::Value json;
   json["success"] = success;
-  json["code"] = result_code.toString();
+  json["code"] = result_code.ToString();
   json["description"] = description;
   return json;
 }

--- a/src/libaktualizr/utilities/types_test.cc
+++ b/src/libaktualizr/utilities/types_test.cc
@@ -34,7 +34,7 @@ TEST(Types, TimeStampNow) {
 TEST(Types, ResultCode) {
   data::ResultCode ok_res{data::ResultCode::Numeric::kOk};
   EXPECT_EQ(ok_res.num_code, data::ResultCode::Numeric::kOk);
-  EXPECT_EQ(ok_res.toString(), "OK");
+  EXPECT_EQ(ok_res.ToString(), "OK");
   std::string repr = ok_res.toRepr();
   EXPECT_EQ(repr, "\"OK\":0");
   EXPECT_EQ(data::ResultCode::fromRepr(repr), ok_res);

--- a/src/libaktualizr/utilities/utils.cc
+++ b/src/libaktualizr/utilities/utils.cc
@@ -933,7 +933,7 @@ Socket::Socket() {
 
 Socket::~Socket() { ::close(socket_fd_); }
 
-std::string Socket::toString() const {
+std::string Socket::ToString() const {
   auto saddr = Utils::ipGetSockaddr(socket_fd_);
   return Utils::ipDisplayName(saddr) + ":" + std::to_string(Utils::ipPort(saddr));
 }

--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -112,7 +112,7 @@ class Socket {
   Socket &operator=(const Socket &) = delete;
 
   int &operator*() { return socket_fd_; }
-  std::string toString() const;
+  std::string ToString() const;
 
  protected:
   void bind(in_port_t port, bool reuse = true) const;

--- a/src/uptane_generator/main.cc
+++ b/src/uptane_generator/main.cc
@@ -186,8 +186,8 @@ int main(int argc, char **argv) {
         std::string dparent = vm["dparent"].as<std::string>();
         std::string dpattern = vm["dpattern"].as<std::string>();
         KeyType key_type = parseKeyType(vm);
-        repo.addDelegation(Uptane::Role(dname, true), Uptane::Role(dparent, dparent != "targets"),
-                           vm["dpattern"].as<std::string>(), vm["dterm"].as<bool>(), key_type);
+        repo.addDelegation(Uptane::Role(dname, true), Uptane::Role(dparent, dparent != "targets"), dpattern,
+                           vm["dterm"].as<bool>(), key_type);
         std::cout << "Added a delegated role " << dname << " with dpattern " << dpattern
                   << " to the Image repo metadata" << std::endl;
       } else if (command == "revokedelegation") {

--- a/src/uptane_generator/repo.cc
+++ b/src/uptane_generator/repo.cc
@@ -122,7 +122,7 @@ std::string Repo::getExpirationTime(const std::string &expires) {
   }
 }
 void Repo::generateKeyPair(KeyType key_type, const Uptane::Role &key_name) {
-  boost::filesystem::path keys_dir = path_ / ("keys/" + repo_type_.toString() + "/" + key_name.ToString());
+  boost::filesystem::path keys_dir = path_ / ("keys/" + repo_type_.ToString() + "/" + key_name.ToString());
   boost::filesystem::create_directories(keys_dir);
 
   std::string public_key_string;
@@ -266,7 +266,7 @@ Json::Value Repo::getTarget(const std::string &target_name) {
 }
 
 void Repo::readKeys() {
-  auto keys_path = path_ / "keys" / repo_type_.toString();
+  auto keys_path = path_ / "keys" / repo_type_.ToString();
   for (auto &p : boost::filesystem::directory_iterator(keys_path)) {
     std::string public_key_string = Utils::readFile(p / "public.key");
     std::istringstream key_type_str(Utils::readFile(p / "key_type"));


### PR DESCRIPTION
I'm tired of trying to remember when it's `toString` and when it's `ToString`.
    
Also added `operator<<` for `RepositoryType`, which is what set off this change.
Moved a couple similar operators to a more logical place as well.
Improved a test to use the uptane_generator library directly instead of making system calls to the executable. (We should really do that pretty much everywhere.)

FYI @mike-sul @cajun-rat.