### PR TITLE
Run clang-tidy on all headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,12 +4,12 @@ Checks:          >-
   bugprone-*,
   cert-*,-cert-err58-cpp,-cert-env33-c,-cert-err60-cpp,
   clang-analyzer-*,
-  cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-init-variables,-cppcoreguidelines-owning-memory,
+  cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-init-variables,-cppcoreguidelines-owning-memory,-cppcoreguidelines-non-private-member-variables-in-classes,-cppcoreguidelines-macro-usage,
   cppcoreguidelines-pro-*,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-pro-type-const-cast,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   google-*,-google-runtime-references,-google-readability-todo,
   hicpp-*,-hicpp-no-array-decay,-hicpp-no-assembler,-hicpp-signed-bitwise,-hicpp-vararg,
   llvm-namespace-comment,
-  misc-*,
+  misc-*,-misc-non-private-member-variables-in-classes,
   modernize-*,-modernize-avoid-bind,-modernize-loop-convert,-modernize-use-trailing-return-type,
   performance-*,
   readability-*,-readability-else-after-return,-readability-identifier-naming,-readability-magic-numbers,
@@ -17,8 +17,6 @@ Checks:          >-
 WarningsAsErrors: '*'
 AnalyzeTemporaryDtors: false
 CheckOptions:
-  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnorePublicMemberVariables
-    value:           '1'
   - key:             cert-dcl59-cpp.HeaderFileExtensions
     value:           h
   - key:             cert-err09-cpp.CheckThrowTemporaries
@@ -52,8 +50,6 @@ CheckOptions:
   - key:             misc-definitions-in-headers.HeaderFileExtensions
     value:           h
   - key:             misc-definitions-in-headers.UseHeaderFileExtension
-    value:           '1'
-  - key:             misc-non-private-member-variables-in-classes.IgnorePublicMemberVariables
     value:           '1'
   - key:             misc-throw-by-value-catch-by-reference.CheckThrowTemporaries
     value:           '1'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,11 +254,6 @@ if(CLANG_TIDY)
     function(aktualizr_clang_tidy)
         file(RELATIVE_PATH SUBDIR ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
         foreach(FILE ${ARGN})
-            # Skip header files, since they are ignored. Headers are checked if
-            # they are included by a checked source file.
-            if(${FILE} MATCHES "\\.h")
-                continue()
-            endif()
             string(REPLACE "/" "_" TARGETNAME "aktualizr_clang_tidy-${SUBDIR}-${FILE}")
             add_custom_target(${TARGETNAME}
                 COMMAND ${PROJECT_SOURCE_DIR}/scripts/clang-tidy-wrapper.sh ${CLANG_TIDY} ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR} ${FILE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,14 +127,13 @@ if(BUILD_P11)
                 message(STATUS "Detected pkcs11 engine path: ${engine}")
                 set(PKCS11_ENGINE_PATH ${engine})
             endif()
-
         endforeach()
 
         if (NOT PKCS11_ENGINE_PATH)
             message(FATAL_ERROR "Could not auto-detect path of PKCS11 engine, please specify PKCS11_ENGINE_PATH")
         endif()
 
-        set(PKCS11_ENGINE_PATH "${PKCS11_ENGINE_PATH}" CACHE STRING "Credentials.zip for tests involving the server")
+        set(PKCS11_ENGINE_PATH "${PKCS11_ENGINE_PATH}" CACHE STRING "Path to PKCS#11 engine library")
     endif()
 endif(BUILD_P11)
 

--- a/include/libaktualizr/aktualizr.h
+++ b/include/libaktualizr/aktualizr.h
@@ -34,9 +34,9 @@ class Aktualizr {
   explicit Aktualizr(const Config& config);
 
   Aktualizr(const Aktualizr&) = delete;
+  Aktualizr(Aktualizr&&) = delete;
   Aktualizr& operator=(const Aktualizr&) = delete;
-  Aktualizr(const Aktualizr&&) = delete;
-  Aktualizr& operator=(const Aktualizr&&) = delete;
+  Aktualizr& operator=(Aktualizr&&) = delete;
   ~Aktualizr();
 
   /**

--- a/include/libaktualizr/campaign.h
+++ b/include/libaktualizr/campaign.h
@@ -28,6 +28,7 @@ enum class Cmd {
 };
 ///! @endcond
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static inline Cmd cmdFromName(const std::string &name) {
   return std::map<std::string, Cmd>{
       {"campaign_accept", Cmd::Accept}, {"campaign_decline", Cmd::Decline}, {"campaign_postpone", Cmd::Postpone}}
@@ -41,9 +42,8 @@ class Campaign {
   static void JsonFromCampaigns(const std::vector<Campaign> &in, Json::Value &out);
   static std::vector<Campaign> fetchAvailableCampaigns(HttpInterface &http_client, const std::string &tls_server);
 
- public:
   Campaign() = default;
-  Campaign(const Json::Value &json);
+  explicit Campaign(const Json::Value &json);
   void getJson(Json::Value &out) const;
 
   std::string id;

--- a/include/libaktualizr/config.h
+++ b/include/libaktualizr/config.h
@@ -180,11 +180,17 @@ struct KeyManagerConfig {
  */
 class BaseConfig {
  public:
+  BaseConfig() = default;
   virtual ~BaseConfig() = default;
   void updateFromToml(const boost::filesystem::path& filename);
   virtual void updateFromPropertyTree(const boost::property_tree::ptree& pt) = 0;
 
  protected:
+  BaseConfig(const BaseConfig&) = default;
+  BaseConfig(BaseConfig&&) = default;
+  BaseConfig& operator=(const BaseConfig&) = default;
+  BaseConfig& operator=(BaseConfig&&) = default;
+
   void updateFromDirs(const std::vector<boost::filesystem::path>& configs);
 
   static void checkDirs(const std::vector<boost::filesystem::path>& configs) {

--- a/include/libaktualizr/events.h
+++ b/include/libaktualizr/events.h
@@ -20,8 +20,12 @@ namespace event {
 class BaseEvent {
  public:
   BaseEvent() = default;
-  BaseEvent(std::string variant_in) : variant(std::move(variant_in)) {}
+  explicit BaseEvent(std::string variant_in) : variant(std::move(variant_in)) {}
   virtual ~BaseEvent() = default;
+  BaseEvent(const BaseEvent&) = default;
+  BaseEvent(BaseEvent&&) = default;
+  BaseEvent& operator=(const BaseEvent&) = default;
+  BaseEvent& operator=(BaseEvent&&) = default;
 
   template <typename T>
   bool isTypeOf() {
@@ -73,7 +77,6 @@ class DownloadProgressReport : public BaseEvent {
     return (report.progress == DownloadProgressReport::ProgressCompletedValue);
   }
 
- public:
   DownloadProgressReport(Uptane::Target target_in, std::string description_in, unsigned int progress_in)
       : target{std::move(target_in)}, description{std::move(description_in)}, progress{progress_in} {
     variant = TypeName;

--- a/include/libaktualizr/packagemanagerinterface.h
+++ b/include/libaktualizr/packagemanagerinterface.h
@@ -41,12 +41,16 @@ enum class TargetStatus {
 
 class PackageManagerInterface {
  public:
-  PackageManagerInterface(const PackageConfig& pconfig, const BootloaderConfig& bconfig,
-                          const std::shared_ptr<INvStorage>& storage, const std::shared_ptr<HttpInterface>& http)
-      : config(pconfig), storage_(storage), http_(http) {
+  PackageManagerInterface(PackageConfig pconfig, const BootloaderConfig& bconfig, std::shared_ptr<INvStorage> storage,
+                          std::shared_ptr<HttpInterface> http)
+      : config(std::move(pconfig)), storage_(std::move(storage)), http_(std::move(http)) {
     (void)bconfig;
   }
   virtual ~PackageManagerInterface() = default;
+  PackageManagerInterface(const PackageManagerInterface&) = delete;
+  PackageManagerInterface(PackageManagerInterface&&) = delete;
+  PackageManagerInterface& operator=(const PackageManagerInterface&) = delete;
+  PackageManagerInterface& operator=(PackageManagerInterface&&) = delete;
   virtual std::string name() const = 0;
   virtual Json::Value getInstalledPackages() const = 0;
   virtual Uptane::Target getCurrent() const = 0;
@@ -57,7 +61,7 @@ class PackageManagerInterface {
   virtual bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                            const FetcherProgressCb& progress_cb, const api::FlowControlToken* token);
   virtual TargetStatus verifyTarget(const Uptane::Target& target) const;
-  virtual bool checkAvailableDiskSpace(const uint64_t required_bytes) const;
+  virtual bool checkAvailableDiskSpace(uint64_t required_bytes) const;
   virtual boost::optional<std::pair<uintmax_t, std::string>> checkTargetFile(const Uptane::Target& target) const;
   virtual std::ofstream createTargetFile(const Uptane::Target& target);
   virtual std::ofstream appendTargetFile(const Uptane::Target& target);

--- a/include/libaktualizr/results.h
+++ b/include/libaktualizr/results.h
@@ -68,6 +68,7 @@ enum class PauseStatus {
 class Pause {
  public:
   Pause() = default;
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
   Pause(PauseStatus status_in) : status(status_in) {}
 
   PauseStatus status{PauseStatus::kSuccess};

--- a/include/libaktualizr/secondary_provider.h
+++ b/include/libaktualizr/secondary_provider.h
@@ -22,9 +22,9 @@ class SecondaryProvider {
   std::ifstream getTargetFileHandle(const Uptane::Target& target) const;
 
  private:
-  SecondaryProvider(Config& config_in, const std::shared_ptr<const INvStorage>& storage_in,
-                    const std::shared_ptr<const PackageManagerInterface>& package_manager_in)
-      : config_(config_in), storage_(storage_in), package_manager_(package_manager_in) {}
+  SecondaryProvider(Config& config_in, std::shared_ptr<const INvStorage> storage_in,
+                    std::shared_ptr<const PackageManagerInterface> package_manager_in)
+      : config_(config_in), storage_(std::move(storage_in)), package_manager_(std::move(package_manager_in)) {}
 
   Config& config_;
   const std::shared_ptr<const INvStorage> storage_;

--- a/include/libaktualizr/secondaryinterface.h
+++ b/include/libaktualizr/secondaryinterface.h
@@ -8,6 +8,9 @@
 
 class SecondaryInterface {
  public:
+  SecondaryInterface() = default;
+  virtual ~SecondaryInterface() = default;
+
   using Ptr = std::shared_ptr<SecondaryInterface>;
 
   virtual void init(std::shared_ptr<SecondaryProvider> secondary_provider_in) = 0;
@@ -27,7 +30,11 @@ class SecondaryInterface {
   virtual data::InstallationResult sendFirmware(const Uptane::Target& target) = 0;
   virtual data::InstallationResult install(const Uptane::Target& target) = 0;
 
-  virtual ~SecondaryInterface() = default;
+ protected:
+  SecondaryInterface(const SecondaryInterface&) = default;
+  SecondaryInterface(SecondaryInterface&&) = default;
+  SecondaryInterface& operator=(const SecondaryInterface&) = default;
+  SecondaryInterface& operator=(SecondaryInterface&&) = default;
 };
 
 #endif  // UPTANE_SECONDARYINTERFACE_H

--- a/include/libaktualizr/types.h
+++ b/include/libaktualizr/types.h
@@ -38,6 +38,7 @@ namespace utils {
  */
 class BasedPath {
  public:
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
   BasedPath(boost::filesystem::path p) : p_(std::move(p)) {}
   boost::filesystem::path get(const boost::filesystem::path &base) const;
   bool empty() const { return p_.empty(); }
@@ -154,7 +155,7 @@ class PublicKey {
  private:
   // std::string can be implicitly converted to a Json::Value. Make sure that
   // the Json::Value constructor is not called accidentally.
-  PublicKey(std::string);
+  PublicKey(std::string);  // NOLINT(google-explicit-constructor, hicpp-explicit-conversions)
   std::string value_;
   KeyType type_{KeyType::kUnknown};
 };
@@ -198,7 +199,7 @@ class TimeStamp {
   static TimeStamp Now();
   static struct tm CurrentTime();
   /** An invalid TimeStamp */
-  TimeStamp() {}
+  TimeStamp() = default;
   explicit TimeStamp(std::string rfc3339);
   explicit TimeStamp(struct tm time);
   bool IsExpiredAt(const TimeStamp &now) const;
@@ -211,8 +212,12 @@ class TimeStamp {
 
   class InvalidTimeStamp : public std::domain_error {
    public:
-    InvalidTimeStamp() : std::domain_error("invalid timestamp") {}
+    InvalidTimeStamp() : std::domain_error("invalid timestamp"){};
     ~InvalidTimeStamp() noexcept override = default;
+    InvalidTimeStamp(const InvalidTimeStamp &) noexcept = default;
+    InvalidTimeStamp(InvalidTimeStamp &&) noexcept = default;
+    InvalidTimeStamp &operator=(const InvalidTimeStamp &) noexcept = default;
+    InvalidTimeStamp &operator=(InvalidTimeStamp &&) noexcept = default;
   };
 
  private:
@@ -249,6 +254,7 @@ struct ResultCode {
   };
 
   // note: intentionally *not* explicit, to make the common case easier
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
   ResultCode(ResultCode::Numeric in_num_code) : num_code(in_num_code) {}
   ResultCode(ResultCode::Numeric in_num_code, std::string text_code_in)
       : num_code(in_num_code), text_code(std::move(text_code_in)) {}
@@ -265,7 +271,7 @@ struct ResultCode {
   // analysis, because the device installation report concatenates the
   // individual ECU ResultCodes.
   std::string ToString() const {
-    if (text_code != "") {
+    if (!text_code.empty()) {
       return text_code;
     }
 
@@ -455,9 +461,9 @@ std::ostream &operator<<(std::ostream &os, const Target &t);
 
 class Manifest : public Json::Value {
  public:
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
   Manifest(const Json::Value &value = Json::Value()) : Json::Value(value) {}
 
- public:
   std::string filepath() const;
   Hash installedImageHash() const;
   std::string signature() const;
@@ -465,6 +471,7 @@ class Manifest : public Json::Value {
   bool verifySignature(const PublicKey &pub_key) const;
 };
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static inline VerificationType VerificationTypeFromString(std::string vt_str) {
   std::transform(vt_str.begin(), vt_str.end(), vt_str.begin(), ::tolower);
   if (vt_str == "tuf") {
@@ -474,6 +481,7 @@ static inline VerificationType VerificationTypeFromString(std::string vt_str) {
   }
 }
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static inline std::string VerificationTypeToString(const VerificationType vtype) {
   std::string type_s;
   switch (vtype) {

--- a/scripts/clang-tidy-wrapper.sh
+++ b/scripts/clang-tidy-wrapper.sh
@@ -12,10 +12,5 @@ if [[ ! -e "${CMAKE_BINARY_DIR}/compile_commands.json" ]]; then
   exit 1
 fi
 
-# Filter out anything that we aren't trying to compile. Older clang-tidy
-# versions (<=6) skipped them automatically.
-if grep -q "${FILE}" "${CMAKE_BINARY_DIR}/compile_commands.json"; then
-  ${CLANG_TIDY} -quiet -header-filter="\(${CMAKE_SOURCE_DIR}|\\.\\.\)/src/.*" --extra-arg-before=-Wno-unknown-warning-option -format-style=file -p "${CMAKE_BINARY_DIR}" "${FILE}"
-else
-  echo "Skipping ${FILE}"
-fi
+${CLANG_TIDY} -quiet -header-filter="\(\(${CMAKE_SOURCE_DIR}|\\.\\.\)/src/|include/libaktualizr/\).*" \
+  --extra-arg-before=-Wno-unknown-warning-option -format-style=file -p "${CMAKE_BINARY_DIR}" "${FILE}"

--- a/src/aktualizr_info/aktualizr_info_config.h
+++ b/src/aktualizr_info/aktualizr_info_config.h
@@ -15,7 +15,7 @@
 class AktualizrInfoConfig : public BaseConfig {
  public:
   AktualizrInfoConfig() = default;
-  AktualizrInfoConfig(const boost::program_options::variables_map& cmd);
+  explicit AktualizrInfoConfig(const boost::program_options::variables_map& cmd);
   explicit AktualizrInfoConfig(const boost::filesystem::path& filename);
 
   void postUpdateValues();

--- a/src/aktualizr_primary/secondary_config.cc
+++ b/src/aktualizr_primary/secondary_config.cc
@@ -10,7 +10,7 @@
 
 namespace Primary {
 
-const char* const IPSecondariesConfig::Type = "IP";
+constexpr const char* const IPSecondariesConfig::Type;
 
 SecondaryConfigParser::Configs SecondaryConfigParser::parse_config_file(const boost::filesystem::path& config_file) {
   if (!boost::filesystem::exists(config_file)) {

--- a/src/aktualizr_primary/secondary_config.h
+++ b/src/aktualizr_primary/secondary_config.h
@@ -1,6 +1,7 @@
 #ifndef SECONDARY_CONFIG_H_
 #define SECONDARY_CONFIG_H_
 
+#include <string>
 #include <unordered_map>
 
 #include <json/json.h>
@@ -25,7 +26,6 @@ class IPSecondaryConfig {
     return os;
   }
 
- public:
   const std::string ip;
   const uint16_t port;
   const VerificationType verification_type;
@@ -33,7 +33,7 @@ class IPSecondaryConfig {
 
 class IPSecondariesConfig : public SecondaryConfig {
  public:
-  static const char* const Type;
+  static constexpr const char* const Type{"IP"};
   static constexpr const char* const PortField{"secondaries_wait_port"};
   static constexpr const char* const TimeoutField{"secondaries_wait_timeout"};
   static constexpr const char* const SecondariesField{"secondaries"};
@@ -46,7 +46,6 @@ class IPSecondariesConfig : public SecondaryConfig {
     return os;
   }
 
- public:
   const uint16_t secondaries_wait_port;
   const int secondaries_timeout_s;
   std::vector<IPSecondaryConfig> secondaries_cfg;
@@ -57,14 +56,19 @@ class SecondaryConfigParser {
   using Configs = std::vector<std::shared_ptr<SecondaryConfig>>;
 
   static Configs parse_config_file(const boost::filesystem::path& config_file);
+  SecondaryConfigParser() = default;
   virtual ~SecondaryConfigParser() = default;
+  SecondaryConfigParser(const SecondaryConfigParser&) = default;
+  SecondaryConfigParser(SecondaryConfigParser&&) = default;
+  SecondaryConfigParser& operator=(const SecondaryConfigParser&) = default;
+  SecondaryConfigParser& operator=(SecondaryConfigParser&&) = default;
 
   virtual Configs parse() = 0;
 };
 
 class JsonConfigParser : public SecondaryConfigParser {
  public:
-  JsonConfigParser(const boost::filesystem::path& config_file);
+  explicit JsonConfigParser(const boost::filesystem::path& config_file);
 
   Configs parse() override;
 
@@ -73,7 +77,6 @@ class JsonConfigParser : public SecondaryConfigParser {
   static void createVirtualSecondariesCfg(Configs& configs, const Json::Value& json_virtual_sec_cfg);
   // add here a factory method for another type of secondary config
 
- private:
   using SecondaryConfigFactoryRegistry = std::unordered_map<std::string, std::function<void(Configs&, Json::Value&)>>;
 
   SecondaryConfigFactoryRegistry sec_cfg_factory_registry_ = {

--- a/src/aktualizr_secondary/aktualizr_secondary_config.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.h
@@ -37,7 +37,7 @@ struct AktualizrSecondaryUptaneConfig {
 class AktualizrSecondaryConfig : public BaseConfig {
  public:
   AktualizrSecondaryConfig() = default;
-  AktualizrSecondaryConfig(const boost::program_options::variables_map& cmd);
+  explicit AktualizrSecondaryConfig(const boost::program_options::variables_map& cmd);
   explicit AktualizrSecondaryConfig(const boost::filesystem::path& filename);
 
   KeyManagerConfig keymanagerConfig() const;

--- a/src/aktualizr_secondary/aktualizr_secondary_file.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_file.h
@@ -11,7 +11,7 @@ class AktualizrSecondaryFile : public AktualizrSecondary {
  public:
   static const std::string FileUpdateDefaultFile;
 
-  AktualizrSecondaryFile(const AktualizrSecondaryConfig& config);
+  explicit AktualizrSecondaryFile(const AktualizrSecondaryConfig& config);
   AktualizrSecondaryFile(const AktualizrSecondaryConfig& config, std::shared_ptr<INvStorage> storage,
                          std::shared_ptr<FileUpdateAgent> update_agent = nullptr);
 

--- a/src/aktualizr_secondary/aktualizr_secondary_ostree.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_ostree.cc
@@ -43,8 +43,8 @@ void AktualizrSecondaryOstree::initialize() {
           AktualizrSecondary::storage()->saveInstalledVersion(serial().ToString(), *pending_target,
                                                               InstalledVersionUpdateMode::kCurrent);
         } else {
-          LOG_ERROR << "Application of the pending update has failed: (" << install_res.result_code.ToString() << ")"
-                    << install_res.description;
+          LOG_ERROR << "Application of the pending update has failed (" << install_res.result_code.ToString()
+                    << "): " << install_res.description;
           AktualizrSecondary::storage()->saveInstalledVersion(serial().ToString(), *pending_target,
                                                               InstalledVersionUpdateMode::kNone);
         }

--- a/src/aktualizr_secondary/aktualizr_secondary_ostree.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_ostree.h
@@ -8,7 +8,7 @@ class OstreeUpdateAgent;
 
 class AktualizrSecondaryOstree : public AktualizrSecondary {
  public:
-  AktualizrSecondaryOstree(const AktualizrSecondaryConfig& config);
+  explicit AktualizrSecondaryOstree(const AktualizrSecondaryConfig& config);
   AktualizrSecondaryOstree(const AktualizrSecondaryConfig& config, const std::shared_ptr<INvStorage>& storage);
 
   void initialize() override;

--- a/src/aktualizr_secondary/aktualizr_secondary_ostree_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_ostree_test.cc
@@ -168,7 +168,7 @@ class UptaneRepoWrapper {
     uptane_repo_.addTarget(rev, hardware_id, serial, "");
     uptane_repo_.signTargets();
 
-    return getCurrentMetadata();
+    return Uptane::SecondaryMetadata(getCurrentMetadata());
   }
 
   Uptane::MetaBundle getCurrentMetadata() const {

--- a/src/aktualizr_secondary/aktualizr_secondary_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_test.cc
@@ -113,7 +113,7 @@ class UptaneRepoWrapper {
       broken_image.close();
     }
 
-    return getCurrentMetadata();
+    return Uptane::SecondaryMetadata(getCurrentMetadata());
   }
 
   void addCustomImageMetadata(const std::string& targetname, const std::string& hardware_id,

--- a/src/aktualizr_secondary/msg_handler.h
+++ b/src/aktualizr_secondary/msg_handler.h
@@ -15,9 +15,9 @@ class MsgHandler {
   MsgHandler() = default;
   virtual ~MsgHandler() = default;
   MsgHandler(const MsgHandler&) = delete;
-  MsgHandler(const MsgHandler&&) = delete;
+  MsgHandler(MsgHandler&&) = delete;
   MsgHandler& operator=(const MsgHandler&) = delete;
-  MsgHandler& operator=(const MsgHandler&&) = delete;
+  MsgHandler& operator=(MsgHandler&&) = delete;
 
  public:
   virtual ReturnCode handleMsg(const Asn1Message::Ptr& in_msg, Asn1Message::Ptr& out_msg) = 0;

--- a/src/aktualizr_secondary/msg_handler.h
+++ b/src/aktualizr_secondary/msg_handler.h
@@ -11,7 +11,6 @@ class MsgHandler {
  public:
   enum ReturnCode { kUnkownMsg = -1, kOk, kRebootRequired };
 
- public:
   MsgHandler() = default;
   virtual ~MsgHandler() = default;
   MsgHandler(const MsgHandler&) = delete;
@@ -19,7 +18,6 @@ class MsgHandler {
   MsgHandler& operator=(const MsgHandler&) = delete;
   MsgHandler& operator=(MsgHandler&&) = delete;
 
- public:
   virtual ReturnCode handleMsg(const Asn1Message::Ptr& in_msg, Asn1Message::Ptr& out_msg) = 0;
 };
 

--- a/src/aktualizr_secondary/secondary_tcp_server.h
+++ b/src/aktualizr_secondary/secondary_tcp_server.h
@@ -23,11 +23,12 @@ class SecondaryTcpServer {
 
   SecondaryTcpServer(MsgHandler& msg_handler, const std::string& primary_ip, in_port_t primary_port, in_port_t port = 0,
                      bool reboot_after_install = false);
-
+  ~SecondaryTcpServer() = default;
   SecondaryTcpServer(const SecondaryTcpServer&) = delete;
+  SecondaryTcpServer(SecondaryTcpServer&&) = delete;
   SecondaryTcpServer& operator=(const SecondaryTcpServer&) = delete;
+  SecondaryTcpServer& operator=(const SecondaryTcpServer&&) = delete;
 
- public:
   /**
    * Accept connections on the socket, decode requests and respond using the secondary implementation
    */
@@ -42,7 +43,6 @@ class SecondaryTcpServer {
  private:
   bool HandleOneConnection(int socket);
 
- private:
   MsgHandler& msg_handler_;
   ListenSocket listen_socket_;
   std::atomic<bool> keep_running_;

--- a/src/aktualizr_secondary/update_agent.h
+++ b/src/aktualizr_secondary/update_agent.h
@@ -8,19 +8,18 @@ class UpdateAgent {
  public:
   using Ptr = std::shared_ptr<UpdateAgent>;
 
- public:
+  virtual ~UpdateAgent() = default;
+  UpdateAgent(const UpdateAgent&) = delete;
+  UpdateAgent(UpdateAgent&&) = delete;
+  UpdateAgent& operator=(const UpdateAgent&) = delete;
+  UpdateAgent& operator=(UpdateAgent&&) = delete;
+
   virtual bool isTargetSupported(const Uptane::Target& target) const = 0;
   virtual bool getInstalledImageInfo(Uptane::InstalledImageInfo& installed_image_info) const = 0;
   virtual data::InstallationResult install(const Uptane::Target& target) = 0;
 
   virtual void completeInstall() = 0;
   virtual data::InstallationResult applyPendingInstall(const Uptane::Target& target) = 0;
-
-  virtual ~UpdateAgent() = default;
-
- public:
-  UpdateAgent(const UpdateAgent&) = delete;
-  UpdateAgent& operator=(const UpdateAgent&) = delete;
 
  protected:
   UpdateAgent() = default;

--- a/src/aktualizr_secondary/update_agent_file.h
+++ b/src/aktualizr_secondary/update_agent_file.h
@@ -10,7 +10,6 @@ class FileUpdateAgent : public UpdateAgent {
         new_target_filepath_{target_filepath_.string() + ".newtarget"},
         current_target_name_{std::move(target_name)} {}
 
- public:
   bool isTargetSupported(const Uptane::Target& target) const override;
   bool getInstalledImageInfo(Uptane::InstalledImageInfo& installed_image_info) const override;
 
@@ -23,7 +22,6 @@ class FileUpdateAgent : public UpdateAgent {
  private:
   static Hash getTargetHash(const Uptane::Target& target);
 
- private:
   const boost::filesystem::path target_filepath_;
   const boost::filesystem::path new_target_filepath_;
   std::string current_target_name_;

--- a/src/aktualizr_secondary/update_agent_ostree.cc
+++ b/src/aktualizr_secondary/update_agent_ostree.cc
@@ -24,7 +24,6 @@ bool OstreeUpdateAgent::getInstalledImageInfo(Uptane::InstalledImageInfo& instal
     if (!currently_installed_target.IsValid()) {
       // This is the policy on a target image name in case of OSTree
       // The policy in followed and implied in meta-updater (garage-sign/push) and the backend
-      // installed_image_info.name = _targetname_prefix + "-" + installed_image_info.hash;
       installed_image_info.name = targetname_prefix_ + "-" + installed_image_info.hash;
     } else {
       installed_image_info.name = currently_installed_target.filename();

--- a/src/aktualizr_secondary/update_agent_ostree.h
+++ b/src/aktualizr_secondary/update_agent_ostree.h
@@ -8,14 +8,13 @@ class KeyManager;
 
 class OstreeUpdateAgent : public UpdateAgent {
  public:
-  OstreeUpdateAgent(const boost::filesystem::path& sysroot_path, std::shared_ptr<KeyManager>& key_mngr,
+  OstreeUpdateAgent(boost::filesystem::path sysroot_path, std::shared_ptr<KeyManager>& key_mngr,
                     std::shared_ptr<OstreeManager>& ostree_pack_man, std::string targetname_prefix)
-      : sysrootPath_(sysroot_path),
+      : sysrootPath_(std::move(sysroot_path)),
         keyMngr_(key_mngr),
         ostreePackMan_(ostree_pack_man),
         targetname_prefix_(std::move(targetname_prefix)) {}
 
- public:
   bool isTargetSupported(const Uptane::Target& target) const override;
   bool getInstalledImageInfo(Uptane::InstalledImageInfo& installed_image_info) const override;
 

--- a/src/libaktualizr-posix/asn1/asn1-cerstream.h
+++ b/src/libaktualizr-posix/asn1/asn1-cerstream.h
@@ -14,13 +14,16 @@ class Token {
   enum TokType { seq_tok, endseq_tok, restseq_tok, expl_tok, peekexpl_tok, endexpl_tok, opt_tok, endopt_tok };
   explicit Token(TokType t) { type = t; }
   virtual ~Token() = default;
+  Token(const Token&) = default;
+  Token(Token&&) = default;
+  Token& operator=(const Token&) = default;
+  Token& operator=(Token&&) = default;
   TokType type;
 };
 
 class EndoptToken : public Token {
  public:
   explicit EndoptToken(bool* result = nullptr) : Token(endopt_tok), result_p(result) {}
-  ~EndoptToken() override = default;
   bool* result_p;
 };
 
@@ -28,7 +31,6 @@ class ExplicitToken : public Token {
  public:
   explicit ExplicitToken(uint8_t token_tag, ASN1_Class token_tag_class = kAsn1Context)
       : Token(expl_tok), tag(token_tag), tag_class(token_tag_class) {}
-  ~ExplicitToken() override = default;
   uint8_t tag;
   ASN1_Class tag_class;
 };
@@ -37,7 +39,6 @@ class PeekExplicitToken : public Token {
  public:
   explicit PeekExplicitToken(uint8_t* token_tag = nullptr, ASN1_Class* token_tag_class = nullptr)
       : Token(peekexpl_tok), tag(token_tag), tag_class(token_tag_class) {}
-  ~PeekExplicitToken() override = default;
   uint8_t* tag;
   ASN1_Class* tag_class;
 };

--- a/src/libaktualizr-posix/asn1/asn1_message.cc
+++ b/src/libaktualizr-posix/asn1/asn1_message.cc
@@ -23,7 +23,7 @@ int Asn1StringAppendCallback(const void* buffer, size_t size, void* priv) {
  * priv is a SocketHandle
  */
 int Asn1SocketWriteCallback(const void* buffer, size_t size, void* priv) {
-  auto sock = reinterpret_cast<int*>(priv);  // NOLINT
+  auto* sock = reinterpret_cast<int*>(priv);
   assert(sock != nullptr);
   assert(-1 < *sock);
 

--- a/src/libaktualizr-posix/asn1/asn1_message.h
+++ b/src/libaktualizr-posix/asn1/asn1_message.h
@@ -37,8 +37,11 @@ class Asn1Message {
   template <typename T>
   using SubPtr = Asn1Sub<T>;
 
+  ~Asn1Message() { ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_AKIpUptaneMes, &msg_); }
   Asn1Message(const Asn1Message&) = delete;
+  Asn1Message(Asn1Message&&) = delete;
   Asn1Message operator=(const Asn1Message&) = delete;
+  Asn1Message operator=(Asn1Message&&) = delete;
 
   /**
    * Create a new Asn1Message, in order to fill it with data and send it
@@ -52,7 +55,6 @@ class Asn1Message {
    */
   static Asn1Message::Ptr FromRaw(AKIpUptaneMes_t** msg) { return new Asn1Message(msg); }
 
-  ~Asn1Message() { ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_AKIpUptaneMes, &msg_); }
   friend void intrusive_ptr_add_ref(Asn1Message* m) { m->ref_count_++; }
   friend void intrusive_ptr_release(Asn1Message* m) {
     if (--m->ref_count_ == 0) {
@@ -101,7 +103,7 @@ class Asn1Message {
   case MessageID:                               \
     return #MessageID;
 
-  const char* toStr() {
+  const char* toStr() const {
     switch (present()) {
       default:
         ASN1_MESSAGE_DEFINE_STR_NAME(AKIpUptaneMes_PR_NOTHING);
@@ -149,6 +151,7 @@ class Asn1Message {
   explicit Asn1Message(AKIpUptaneMes_t** msg) {
     if (msg != nullptr && *msg != nullptr) {
       memmove(&msg_, *msg, sizeof(AKIpUptaneMes_t));
+      // NOLINTNEXTLINE(cppcoreguidelines-no-malloc, hicpp-no-malloc)
       free(*msg);  // Be careful. This needs to be the same free() used in der_decode
       *msg = nullptr;
     }
@@ -186,6 +189,7 @@ Asn1Message::Ptr Asn1Rpc(const Asn1Message::Ptr& tx, const std::pair<std::string
  */
 template <typename T>
 T* Asn1Allocation() {
+  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc, hicpp-no-malloc)
   auto ptr = static_cast<T*>(calloc(1, sizeof(T)));
   if (!ptr) {
     throw std::bad_alloc();

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -1,3 +1,5 @@
+#include "ipuptanesecondary.h"
+
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 
@@ -6,8 +8,9 @@
 
 #include "asn1/asn1_message.h"
 #include "der_encoder.h"
-#include "ipuptanesecondary.h"
 #include "logging/logging.h"
+#include "uptane/tuf.h"
+#include "utilities/utils.h"
 
 namespace Uptane {
 

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -8,7 +8,6 @@
 #include "der_encoder.h"
 #include "ipuptanesecondary.h"
 #include "logging/logging.h"
-#include "storage/invstorage.h"
 
 namespace Uptane {
 

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -340,7 +340,7 @@ Manifest IpUptaneSecondary::getManifest() const {
     LOG_ERROR << "Manifest wasn't in json format";
     return Json::Value();
   }
-  std::string manifest = ToString(r->manifest.choice.json);  // NOLINT
+  std::string manifest = ToString(r->manifest.choice.json);  // NOLINT(cppcoreguidelines-pro-type-union-access)
   return Utils::parseJSON(manifest);
 }
 

--- a/src/libaktualizr/bootloader/bootloader.h
+++ b/src/libaktualizr/bootloader/bootloader.h
@@ -8,7 +8,11 @@ class INvStorage;
 class Bootloader {
  public:
   Bootloader(BootloaderConfig config, INvStorage& storage);
-  virtual ~Bootloader() {}
+  virtual ~Bootloader() = default;
+  Bootloader(const Bootloader&) = delete;
+  Bootloader(Bootloader&&) = delete;
+  Bootloader& operator=(const Bootloader&) = delete;
+  Bootloader& operator=(Bootloader&&) = delete;
   virtual void setBootOK() const;
   virtual void updateNotify() const;
 

--- a/src/libaktualizr/crypto/crypto.h
+++ b/src/libaktualizr/crypto/crypto.h
@@ -18,13 +18,20 @@
 #include "libaktualizr/types.h"
 #include "utilities/utils.h"
 
-// some older versions of openssl have BIO_new_mem_buf defined with fisrt parameter of type (void*)
+// some older versions of openssl have BIO_new_mem_buf defined with first parameter of type (void*)
 //   which is not true and breaks our build
 #undef BIO_new_mem_buf
-BIO *BIO_new_mem_buf(const void *, int);
+BIO *BIO_new_mem_buf(const void *, int);  // NOLINT(readability-redundant-declaration)
 
 class MultiPartHasher {
  public:
+  MultiPartHasher() = default;
+  virtual ~MultiPartHasher() = default;
+  MultiPartHasher(const MultiPartHasher &) = delete;
+  MultiPartHasher(MultiPartHasher &&) = delete;
+  MultiPartHasher &operator=(const MultiPartHasher &) = delete;
+  MultiPartHasher &operator=(MultiPartHasher &&) = delete;
+
   using Ptr = std::shared_ptr<MultiPartHasher>;
   static Ptr create(Hash::Type hash_type);
 
@@ -32,13 +39,16 @@ class MultiPartHasher {
   virtual void reset() = 0;
   virtual std::string getHexDigest() = 0;
   virtual Hash getHash() = 0;
-  virtual ~MultiPartHasher() = default;
 };
 
 class MultiPartSHA512Hasher : public MultiPartHasher {
  public:
   MultiPartSHA512Hasher() { crypto_hash_sha512_init(&state_); }
   ~MultiPartSHA512Hasher() override = default;
+  MultiPartSHA512Hasher(const MultiPartSHA512Hasher &) = delete;
+  MultiPartSHA512Hasher(MultiPartSHA512Hasher &&) = delete;
+  MultiPartSHA512Hasher &operator=(const MultiPartSHA512Hasher &) = delete;
+  MultiPartSHA512Hasher &operator=(MultiPartSHA512Hasher &&) = delete;
   void update(const unsigned char *part, uint64_t size) override { crypto_hash_sha512_update(&state_, part, size); }
   void reset() override { crypto_hash_sha512_init(&state_); }
   std::string getHexDigest() override {
@@ -57,6 +67,10 @@ class MultiPartSHA256Hasher : public MultiPartHasher {
  public:
   MultiPartSHA256Hasher() { crypto_hash_sha256_init(&state_); }
   ~MultiPartSHA256Hasher() override = default;
+  MultiPartSHA256Hasher(const MultiPartSHA256Hasher &) = delete;
+  MultiPartSHA256Hasher(MultiPartSHA256Hasher &&) = delete;
+  MultiPartSHA256Hasher &operator=(const MultiPartSHA256Hasher &) = delete;
+  MultiPartSHA256Hasher &operator=(MultiPartSHA256Hasher &&) = delete;
   void update(const unsigned char *part, uint64_t size) override { crypto_hash_sha256_update(&state_, part, size); }
   void reset() override { crypto_hash_sha256_init(&state_); }
   std::string getHexDigest() override {
@@ -82,7 +96,7 @@ class Crypto {
                        std::string *out_ca);
   static std::string extractSubjectCN(const std::string &cert);
   static StructGuard<EVP_PKEY> generateRSAKeyPairEVP(KeyType key_type);
-  static StructGuard<EVP_PKEY> generateRSAKeyPairEVP(const int bits);
+  static StructGuard<EVP_PKEY> generateRSAKeyPairEVP(int bits);
   static bool generateRSAKeyPair(KeyType key_type, std::string *public_key, std::string *private_key);
   static bool generateEDKeyPair(std::string *public_key, std::string *private_key);
   static bool generateKeyPair(KeyType key_type, std::string *public_key, std::string *private_key);
@@ -93,11 +107,11 @@ class Crypto {
   static bool IsRsaKeyType(KeyType type);
   static KeyType IdentifyRSAKeyType(const std::string &public_key_pem);
 
-  static StructGuard<X509> generateCert(const int rsa_bits, const int cert_days, const std::string &cert_c,
+  static StructGuard<X509> generateCert(int rsa_bits, int cert_days, const std::string &cert_c,
                                         const std::string &cert_st, const std::string &cert_o,
                                         const std::string &cert_cn, bool self_sign = false);
-  static void signCert(const std::string &cacert_path, const std::string &capkey_path, X509 *const certificate);
-  static void serializeCert(std::string *pkey, std::string *cert, X509 *const certificate);
+  static void signCert(const std::string &cacert_path, const std::string &capkey_path, X509 *certificate);
+  static void serializeCert(std::string *pkey, std::string *cert, X509 *certificate);
 };
 
 #endif  // CRYPTO_H_

--- a/src/libaktualizr/crypto/keymanager.h
+++ b/src/libaktualizr/crypto/keymanager.h
@@ -27,7 +27,7 @@ class KeyManager {
   std::string getCa() const;
   std::string getCN() const;
   void getCertInfo(std::string *subject, std::string *issuer, std::string *not_before, std::string *not_after) const;
-  bool isOk() const { return ((getPkey().size() != 0U) && (getCert().size() != 0U) && (getCa().size() != 0U)); }
+  bool isOk() const { return (!getPkey().empty() && !getCert().empty() && !getCa().empty()); }
   std::string generateUptaneKeyPair();
   KeyType getUptaneKeyType() const { return config_.uptane_key_type; }
   Json::Value signTuf(const Json::Value &in_data) const;

--- a/src/libaktualizr/crypto/p11engine.h
+++ b/src/libaktualizr/crypto/p11engine.h
@@ -16,7 +16,9 @@ class P11ContextWrapper {
   explicit P11ContextWrapper(const boost::filesystem::path &module);
   ~P11ContextWrapper();  // NOLINT(performance-trivially-destructible)
   P11ContextWrapper(const P11ContextWrapper &) = delete;
+  P11ContextWrapper(P11ContextWrapper &&) = delete;
   P11ContextWrapper &operator=(const P11ContextWrapper &) = delete;
+  P11ContextWrapper &operator=(P11ContextWrapper &&) = delete;
   PKCS11_ctx_st *get() const { return ctx; }
 
  private:
@@ -28,13 +30,15 @@ class P11SlotsWrapper {
   explicit P11SlotsWrapper(PKCS11_ctx_st *ctx_in);
   ~P11SlotsWrapper();  // NOLINT(performance-trivially-destructible)
   P11SlotsWrapper(const P11SlotsWrapper &) = delete;
+  P11SlotsWrapper(P11SlotsWrapper &&) = delete;
   P11SlotsWrapper &operator=(const P11SlotsWrapper &) = delete;
-  PKCS11_slot_st *get_slots() const { return wslots_; }
+  P11SlotsWrapper &operator=(P11SlotsWrapper &&) = delete;
+  PKCS11_slot_st *get_slots() const { return slots_; }
   unsigned int get_nslots() const { return nslots; }
 
  private:
   PKCS11_ctx_st *ctx;  // NOLINT
-  PKCS11_slot_st *wslots_;
+  PKCS11_slot_st *slots_;
   unsigned int nslots;
 };
 
@@ -43,7 +47,9 @@ class P11EngineGuard;
 class P11Engine {
  public:
   P11Engine(const P11Engine &) = delete;
+  P11Engine(P11Engine &&) = delete;
   P11Engine &operator=(const P11Engine &) = delete;
+  P11Engine &operator=(P11Engine &&) = delete;
 
   virtual ~P11Engine() {
     if (ssl_engine_ != nullptr) {
@@ -67,7 +73,7 @@ class P11Engine {
   ENGINE *ssl_engine_{nullptr};
   std::string uri_prefix_;
   P11ContextWrapper ctx_;
-  P11SlotsWrapper slots_;
+  P11SlotsWrapper wslots_;
 
   static boost::filesystem::path findPkcsLibrary();
   PKCS11_slot_st *findTokenSlot() const;
@@ -85,7 +91,8 @@ class P11EngineGuard {
       instance = new P11Engine(config);
     }
     ++ref_counter;
-  };
+  }
+
   ~P11EngineGuard() {
     if (ref_counter != 0) {
       --ref_counter;
@@ -95,6 +102,12 @@ class P11EngineGuard {
       instance = nullptr;
     }
   }
+
+  P11EngineGuard(const P11EngineGuard &) = delete;
+  P11EngineGuard(P11EngineGuard &&) = delete;
+  P11EngineGuard &operator=(const P11EngineGuard &) = delete;
+  P11EngineGuard &operator=(P11EngineGuard &&) = delete;
+
   P11Engine *operator->() const { return instance; }
 
  private:

--- a/src/libaktualizr/crypto/p11engine_dummy.cc
+++ b/src/libaktualizr/crypto/p11engine_dummy.cc
@@ -10,7 +10,7 @@ P11ContextWrapper::P11ContextWrapper(const boost::filesystem::path& module) : ct
 
 P11ContextWrapper::~P11ContextWrapper() = default;
 
-P11SlotsWrapper::P11SlotsWrapper(PKCS11_ctx_st* ctx_in) : ctx(nullptr), wslots_(nullptr), nslots(0) {
+P11SlotsWrapper::P11SlotsWrapper(PKCS11_ctx_st* ctx_in) : ctx(nullptr), slots_(nullptr), nslots(0) {
   (void)ctx_in;
   throw std::runtime_error("Aktualizr was built without PKCS#11");
 }

--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -302,7 +302,7 @@ void HttpClient::timeout(int64_t ms) {
   // curl_easy_setopt() takes a 'long' be very sure that we are passing
   // whatever the platform ABI thinks is a long, while keeping the external
   // interface a clang-tidy preferred int64
-  auto ms_long = static_cast<long>(ms);  // NOLINT
+  auto ms_long = static_cast<long>(ms);  // NOLINT(google-runtime-int)
   curlEasySetoptWrapper(curl, CURLOPT_TIMEOUT_MS, ms_long);
   curlEasySetoptWrapper(curl, CURLOPT_CONNECTTIMEOUT_MS, ms_long);
 }

--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -87,7 +87,8 @@ HttpClient::HttpClient(const std::string& socket) {
   curlEasySetoptWrapper(curl, CURLOPT_USERAGENT, Utils::getUserAgent());
 }
 
-HttpClient::HttpClient(const HttpClient& curl_in) : pkcs11_key(curl_in.pkcs11_key), pkcs11_cert(curl_in.pkcs11_key) {
+HttpClient::HttpClient(const HttpClient& curl_in)
+    : HttpInterface(curl_in), pkcs11_key(curl_in.pkcs11_key), pkcs11_cert(curl_in.pkcs11_key) {
   curl = curl_easy_duphandle(curl_in.curl);
   headers = curl_slist_dup(curl_in.headers);
 }

--- a/src/libaktualizr/http/httpclient.h
+++ b/src/libaktualizr/http/httpclient.h
@@ -28,9 +28,12 @@ class CurlGlobalInitWrapper {
 class HttpClient : public HttpInterface {
  public:
   explicit HttpClient(const std::vector<std::string> *extra_headers = nullptr);
-  HttpClient(const std::string &socket);
-  HttpClient(const HttpClient & /*curl_in*/);
+  explicit HttpClient(const std::string &socket);
+  HttpClient(const HttpClient &curl_in);  // non-default!
   ~HttpClient() override;
+  HttpClient(HttpClient &&) = default;
+  HttpClient &operator=(const HttpClient &) = delete;
+  HttpClient &operator=(HttpClient &&) = default;
   HttpResponse get(const std::string &url, int64_t maxsize) override;
   HttpResponse post(const std::string &url, const std::string &content_type, const std::string &data) override;
   HttpResponse post(const std::string &url, const Json::Value &data) override;

--- a/src/libaktualizr/http/httpclient.h
+++ b/src/libaktualizr/http/httpclient.h
@@ -19,10 +19,10 @@ class CurlGlobalInitWrapper {
  public:
   CurlGlobalInitWrapper() { curl_global_init(CURL_GLOBAL_DEFAULT); }
   ~CurlGlobalInitWrapper() { curl_global_cleanup(); }
-  CurlGlobalInitWrapper &operator=(const CurlGlobalInitWrapper &) = delete;
   CurlGlobalInitWrapper(const CurlGlobalInitWrapper &) = delete;
-  CurlGlobalInitWrapper &operator=(CurlGlobalInitWrapper &&) = delete;
   CurlGlobalInitWrapper(CurlGlobalInitWrapper &&) = delete;
+  CurlGlobalInitWrapper &operator=(const CurlGlobalInitWrapper &) = delete;
+  CurlGlobalInitWrapper &operator=(CurlGlobalInitWrapper &&) = delete;
 };
 
 class HttpClient : public HttpInterface {

--- a/src/libaktualizr/http/httpinterface.h
+++ b/src/libaktualizr/http/httpinterface.h
@@ -37,6 +37,7 @@ struct HttpResponse {
 
 class HttpInterface {
  public:
+  HttpInterface() = default;
   virtual ~HttpInterface() = default;
   virtual HttpResponse get(const std::string &url, int64_t maxsize) = 0;
   virtual HttpResponse post(const std::string &url, const std::string &content_type, const std::string &data) = 0;
@@ -54,6 +55,12 @@ class HttpInterface {
   static constexpr int64_t kNoLimit = 0;  // no limit the size of downloaded data
   static constexpr int64_t kPostRespLimit = 64 * 1024;
   static constexpr int64_t kPutRespLimit = 64 * 1024;
+
+ protected:
+  HttpInterface(const HttpInterface &) = default;
+  HttpInterface(HttpInterface &&) = default;
+  HttpInterface &operator=(const HttpInterface &) = default;
+  HttpInterface &operator=(HttpInterface &&) = default;
 };
 
 #endif  // HTTPINTERFACE_H_

--- a/src/libaktualizr/package_manager/ostreemanager.h
+++ b/src/libaktualizr/package_manager/ostreemanager.h
@@ -45,6 +45,10 @@ class OstreeManager : public PackageManagerInterface {
                 const std::shared_ptr<INvStorage> &storage, const std::shared_ptr<HttpInterface> &http,
                 Bootloader *bootloader = nullptr);
   ~OstreeManager() override;
+  OstreeManager(const OstreeManager &) = delete;
+  OstreeManager(OstreeManager &&) = delete;
+  OstreeManager &operator=(const OstreeManager &) = delete;
+  OstreeManager &operator=(OstreeManager &&) = delete;
   std::string name() const override { return "ostree"; }
   Json::Value getInstalledPackages() const override;
   virtual std::string getCurrentHash() const;

--- a/src/libaktualizr/package_manager/packagemanagerfake.h
+++ b/src/libaktualizr/package_manager/packagemanagerfake.h
@@ -14,6 +14,10 @@ class PackageManagerFake : public PackageManagerInterface {
                      const std::shared_ptr<INvStorage> &storage, const std::shared_ptr<HttpInterface> &http)
       : PackageManagerInterface(pconfig, bconfig, storage, http), bootloader_{new Bootloader(bconfig, *storage_)} {}
   ~PackageManagerFake() override = default;
+  PackageManagerFake(const PackageManagerFake &) = delete;
+  PackageManagerFake(PackageManagerFake &&) = delete;
+  PackageManagerFake &operator=(const PackageManagerFake &) = delete;
+  PackageManagerFake &operator=(PackageManagerFake &&) = delete;
   std::string name() const override { return "fake"; }
   Json::Value getInstalledPackages() const override;
 

--- a/src/libaktualizr/primary/provisioner.h
+++ b/src/libaktualizr/primary/provisioner.h
@@ -1,6 +1,8 @@
 #ifndef INITIALIZER_H_
 #define INITIALIZER_H_
 
+#include <string>
+
 #include "libaktualizr/secondaryinterface.h"
 
 #include "crypto/keymanager.h"

--- a/src/libaktualizr/primary/provisioner_test_utils.cc
+++ b/src/libaktualizr/primary/provisioner_test_utils.cc
@@ -1,8 +1,7 @@
+#include "provisioner_test_utils.h"
 
 #include <gtest/gtest.h>
-#include "primary/provisioner.h"
 
-// Test utility to run provisioning to completion and check the result
 void ExpectProvisionOK(Provisioner&& provisioner) {
   int attempts = 0;
   bool last_attempt = false;
@@ -17,7 +16,7 @@ void ExpectProvisionOK(Provisioner&& provisioner) {
   EXPECT_EQ(provisioner.CurrentState(), Provisioner::State::kOk);
 }
 
-void ExpectProvisionError(Provisioner&& provisioner, const std::string& match = "") {
+void ExpectProvisionError(Provisioner&& provisioner, const std::string& match) {
   bool last_attempt;
   for (int attempt = 0; attempt < 3; attempt++) {
     EXPECT_TRUE(provisioner.ShouldAttemptAgain());

--- a/src/libaktualizr/primary/provisioner_test_utils.h
+++ b/src/libaktualizr/primary/provisioner_test_utils.h
@@ -1,11 +1,11 @@
-
 #ifndef AKTUALIZR_PROVISIONER_TEST_UTILS_H
 #define AKTUALIZR_PROVISIONER_TEST_UTILS_H
 
-// TODO documenti
+#include "primary/provisioner.h"
+
+// Test utility to run provisioning to completion and check the result
 void ExpectProvisionOK(Provisioner&& provisioner);
 
-// TODO documenti
 void ExpectProvisionError(Provisioner&& provisioner, const std::string& match = "");
 
 #endif  // AKTUALIZR_PROVISIONER_TEST_UTILS_H

--- a/src/libaktualizr/primary/reportqueue.h
+++ b/src/libaktualizr/primary/reportqueue.h
@@ -35,27 +35,27 @@ class ReportEvent {
 
 class CampaignAcceptedReport : public ReportEvent {
  public:
-  CampaignAcceptedReport(const std::string& campaign_id);
+  explicit CampaignAcceptedReport(const std::string& campaign_id);
 };
 
 class CampaignDeclinedReport : public ReportEvent {
  public:
-  CampaignDeclinedReport(const std::string& campaign_id);
+  explicit CampaignDeclinedReport(const std::string& campaign_id);
 };
 
 class CampaignPostponedReport : public ReportEvent {
  public:
-  CampaignPostponedReport(const std::string& campaign_id);
+  explicit CampaignPostponedReport(const std::string& campaign_id);
 };
 
 class DevicePausedReport : public ReportEvent {
  public:
-  DevicePausedReport(const std::string& correlation_id);
+  explicit DevicePausedReport(const std::string& correlation_id);
 };
 
 class DeviceResumedReport : public ReportEvent {
  public:
-  DeviceResumedReport(const std::string& correlation_id);
+  explicit DeviceResumedReport(const std::string& correlation_id);
 };
 
 class EcuDownloadStartedReport : public ReportEvent {
@@ -88,6 +88,10 @@ class ReportQueue {
   ReportQueue(const Config& config_in, std::shared_ptr<HttpInterface> http_client,
               std::shared_ptr<INvStorage> storage_in);
   ~ReportQueue();
+  ReportQueue(const ReportQueue&) = delete;
+  ReportQueue(ReportQueue&&) = delete;
+  ReportQueue& operator=(const ReportQueue&) = delete;
+  ReportQueue& operator=(ReportQueue&&) = delete;
   void run();
   void enqueue(std::unique_ptr<ReportEvent> event);
 

--- a/src/libaktualizr/primary/secondary_config.h
+++ b/src/libaktualizr/primary/secondary_config.h
@@ -1,16 +1,24 @@
 #ifndef PRIMARY_SECONDARY_CONFIG_H_
 #define PRIMARY_SECONDARY_CONFIG_H_
 
+#include <string>
+
 namespace Primary {
 
 class SecondaryConfig {
  public:
-  explicit SecondaryConfig(const char* type) : type_(type) {}
-  virtual const char* type() const { return type_; }
+  explicit SecondaryConfig(std::string type) : type_(std::move(type)) {}
   virtual ~SecondaryConfig() = default;
+  virtual std::string type() const { return type_; }
+
+ protected:
+  SecondaryConfig(const SecondaryConfig &) = default;
+  SecondaryConfig(SecondaryConfig &&) = default;
+  SecondaryConfig &operator=(const SecondaryConfig &) = default;
+  SecondaryConfig &operator=(SecondaryConfig &&) = default;
 
  private:
-  const char* const type_;
+  std::string type_;
 };
 
 }  // namespace Primary

--- a/src/libaktualizr/primary/secondary_provider_builder.h
+++ b/src/libaktualizr/primary/secondary_provider_builder.h
@@ -8,15 +8,17 @@
 class SecondaryProviderBuilder {
  public:
   static std::shared_ptr<SecondaryProvider> Build(
-      Config& config, const std::shared_ptr<const INvStorage>& storage,
-      const std::shared_ptr<const PackageManagerInterface>& package_manager) {
+      Config &config, const std::shared_ptr<const INvStorage> &storage,
+      const std::shared_ptr<const PackageManagerInterface> &package_manager) {
     return std::make_shared<SecondaryProvider>(SecondaryProvider(config, storage, package_manager));
   }
-  SecondaryProviderBuilder(SecondaryProviderBuilder&&) = delete;
-  SecondaryProviderBuilder(const SecondaryProviderBuilder&) = delete;
-  SecondaryProviderBuilder& operator=(const SecondaryProviderBuilder&) = delete;
+  ~SecondaryProviderBuilder() = default;
+  SecondaryProviderBuilder(const SecondaryProviderBuilder &) = delete;
+  SecondaryProviderBuilder(SecondaryProviderBuilder &&) = delete;
+  SecondaryProviderBuilder &operator=(const SecondaryProviderBuilder &) = delete;
+  SecondaryProviderBuilder &operator=(SecondaryProviderBuilder &&) = delete;
 
  private:
-  SecondaryProviderBuilder() {}
+  SecondaryProviderBuilder() = default;
 };
 #endif  // UPTANE_SECONDARY_PROVIDER_BUILDER_H

--- a/src/libaktualizr/storage/fsstorage_read.h
+++ b/src/libaktualizr/storage/fsstorage_read.h
@@ -8,6 +8,10 @@ class FSStorageRead {
  public:
   explicit FSStorageRead(const StorageConfig& config);
   ~FSStorageRead() = default;
+  FSStorageRead(const FSStorageRead&) = delete;
+  FSStorageRead(FSStorageRead&&) = delete;
+  FSStorageRead& operator=(const FSStorageRead&) = delete;
+  FSStorageRead& operator=(FSStorageRead&&) = delete;
   bool loadPrimaryKeys(std::string* public_key, std::string* private_key) const;
   bool loadPrimaryPublic(std::string* public_key) const;
   bool loadPrimaryPrivate(std::string* private_key) const;

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -44,6 +44,10 @@ class INvStorage {
  public:
   explicit INvStorage(StorageConfig config) : config_(std::move(config)) {}
   virtual ~INvStorage() = default;
+  INvStorage(const INvStorage&) = delete;
+  INvStorage(INvStorage&&) = delete;
+  INvStorage& operator=(const INvStorage&) = delete;
+  INvStorage& operator=(INvStorage&&) = delete;
   virtual StorageType type() = 0;
   virtual void storePrimaryKeys(const std::string& public_key, const std::string& private_key) = 0;
   virtual bool loadPrimaryKeys(std::string* public_key, std::string* private_key) const = 0;

--- a/src/libaktualizr/storage/sql_utils.h
+++ b/src/libaktualizr/storage/sql_utils.h
@@ -4,6 +4,8 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
+#include <string>
 
 #include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
@@ -21,14 +23,12 @@ struct SQLBlob {
 
 class SQLException : public std::runtime_error {
  public:
-  SQLException(const std::string& what = "SQL error") : std::runtime_error(what) {}
-  ~SQLException() noexcept override = default;
+  explicit SQLException(const std::string& what = "SQL error") : std::runtime_error(what) {}
 };
 
 class SQLInternalException : public SQLException {
  public:
-  SQLInternalException(const std::string& what = "SQL internal error") : SQLException(what) {}
-  ~SQLInternalException() noexcept override = default;
+  explicit SQLInternalException(const std::string& what = "SQL internal error") : SQLException(what) {}
 };
 
 class SQLiteStatement {
@@ -164,7 +164,8 @@ class SQLite3Guard {
     }
   }
   SQLite3Guard(const SQLite3Guard& guard) = delete;
-  SQLite3Guard operator=(const SQLite3Guard& guard) = delete;
+  SQLite3Guard& operator=(const SQLite3Guard& guard) = delete;
+  SQLite3Guard& operator=(SQLite3Guard&&) = delete;
 
   int exec(const char* sql, int (*callback)(void*, int, char**, char**), void* cb_arg) {
     return sqlite3_exec(handle_.get(), sql, callback, cb_arg, nullptr);

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -21,6 +21,10 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
   friend class SQLTargetRHandle;
   explicit SQLStorage(const StorageConfig& config, bool readonly);
   ~SQLStorage() override = default;
+  SQLStorage(const SQLStorage&) = delete;
+  SQLStorage(SQLStorage&&) = delete;
+  SQLStorage& operator=(const SQLStorage&) = delete;
+  SQLStorage& operator=(SQLStorage&&) = delete;
   void storePrimaryKeys(const std::string& public_key, const std::string& private_key) override;
   bool loadPrimaryKeys(std::string* public_key, std::string* private_key) const override;
   bool loadPrimaryPublic(std::string* public_key) const override;

--- a/src/libaktualizr/storage/sqlstorage_base.h
+++ b/src/libaktualizr/storage/sqlstorage_base.h
@@ -13,12 +13,12 @@ enum class DbVersion : int32_t { kEmpty = -1, kInvalid = -2 };
 class StorageLock {
  public:
   StorageLock() = default;
-  StorageLock(boost::filesystem::path path);
-  StorageLock(StorageLock &other) = delete;
-  StorageLock &operator=(StorageLock &other) = delete;
-  StorageLock(StorageLock &&other) = default;
-  StorageLock &operator=(StorageLock &&other) = default;
+  explicit StorageLock(boost::filesystem::path path);
   virtual ~StorageLock();
+  StorageLock(const StorageLock &other) = delete;
+  StorageLock(StorageLock &&other) = default;
+  StorageLock &operator=(const StorageLock &other) = delete;
+  StorageLock &operator=(StorageLock &&other) = default;
 
   class locked_exception : std::runtime_error {
    public:
@@ -35,7 +35,6 @@ class SQLStorageBase {
   explicit SQLStorageBase(boost::filesystem::path sqldb_path, bool readonly, std::vector<std::string> schema_migrations,
                           std::vector<std::string> schema_rollback_migrations, std::string current_schema,
                           int current_schema_version);
-  ~SQLStorageBase() = default;
   std::string getTableSchemaFromDb(const std::string &tablename);
   bool dbMigrateForward(int version_from, int version_to = 0);
   bool dbMigrateBackward(int version_from, int version_to = 0);

--- a/src/libaktualizr/storage/storage_exception.h
+++ b/src/libaktualizr/storage/storage_exception.h
@@ -1,10 +1,12 @@
 #ifndef STORAGE_EXCEPTION_H_
 #define STORAGE_EXCEPTION_H_
 
+#include <stdexcept>
+#include <string>
+
 class StorageException : public std::runtime_error {
  public:
-  StorageException(const std::string& what) : std::runtime_error(what) {}
-  ~StorageException() noexcept override = default;
+  explicit StorageException(const std::string& what) : std::runtime_error(what) {}
 };
 
 #endif  // STORAGE_EXCEPTION_H_

--- a/src/libaktualizr/uptane/directorrepository.h
+++ b/src/libaktualizr/uptane/directorrepository.h
@@ -28,13 +28,13 @@ class DirectorRepository : public RepositoryCommon {
   bool matchTargetsWithImageTargets(const std::shared_ptr<const Uptane::Targets>& image_targets) const;
 
  private:
+  FRIEND_TEST(Director, EmptyTargets);
+
   void resetMeta();
   void checkTargetsExpired();
   void targetsSanityCheck();
   bool usePreviousTargets() const;
 
- private:
-  FRIEND_TEST(Director, EmptyTargets);
   // Since the Director can send us an empty targets list to mean "no new
   // updates", we have to persist the previous targets list. Use the latest for
   // checking expiration but the most recent non-empty list for everything else.

--- a/src/libaktualizr/uptane/exceptions.h
+++ b/src/libaktualizr/uptane/exceptions.h
@@ -11,7 +11,6 @@ class Exception : public std::logic_error {
  public:
   Exception(std::string reponame, const std::string& what_arg)
       : std::logic_error(what_arg.c_str()), reponame_(std::move(reponame)) {}
-  ~Exception() noexcept override = default;
   virtual std::string getName() const { return reponame_; };
 
  protected:
@@ -22,115 +21,98 @@ class MetadataFetchFailure : public Exception {
  public:
   MetadataFetchFailure(const std::string& reponame, const std::string& role)
       : Exception(reponame, std::string("Failed to fetch role ") + role + " in " + reponame + " repository.") {}
-  ~MetadataFetchFailure() noexcept override = default;
 };
 
 class SecurityException : public Exception {
  public:
   SecurityException(const std::string& reponame, const std::string& what_arg) : Exception(reponame, what_arg) {}
-  ~SecurityException() noexcept override = default;
 };
 
 class TargetContentMismatch : public Exception {
  public:
   explicit TargetContentMismatch(const std::string& targetname)
       : Exception(targetname, "Director Target filename matches currently installed version, but content differs.") {}
-  ~TargetContentMismatch() noexcept override = default;
 };
 
 class TargetHashMismatch : public Exception {
  public:
   explicit TargetHashMismatch(const std::string& targetname)
       : Exception(targetname, "The target's calculated hash did not match the hash in the metadata.") {}
-  ~TargetHashMismatch() noexcept override = default;
 };
 
 class OversizedTarget : public Exception {
  public:
   explicit OversizedTarget(const std::string& reponame)
       : Exception(reponame, "The target's size was greater than the size in the metadata.") {}
-  ~OversizedTarget() noexcept override = default;
 };
 
 class IllegalThreshold : public Exception {
  public:
   IllegalThreshold(const std::string& reponame, const std::string& what_arg) : Exception(reponame, what_arg) {}
-  ~IllegalThreshold() noexcept override = default;
 };
 
 class MissingRepo : public Exception {
  public:
   explicit MissingRepo(const std::string& reponame) : Exception(reponame, "The " + reponame + " repo is missing.") {}
-  ~MissingRepo() noexcept override = default;
 };
 
 class UnmetThreshold : public Exception {
  public:
   UnmetThreshold(const std::string& reponame, const std::string& role)
       : Exception(reponame, "The " + role + " metadata had an unmet threshold.") {}
-  ~UnmetThreshold() noexcept override = default;
 };
 
 class ExpiredMetadata : public Exception {
  public:
   ExpiredMetadata(const std::string& reponame, const std::string& role)
       : Exception(reponame, "The " + role + " metadata was expired.") {}
-  ~ExpiredMetadata() noexcept override = default;
 };
 
 class InvalidMetadata : public Exception {
  public:
   InvalidMetadata(const std::string& reponame, const std::string& role, const std::string& reason)
       : Exception(reponame, "The " + role + " metadata failed to parse: " + reason) {}
-  ~InvalidMetadata() noexcept override = default;
 };
 
 class TargetMismatch : public Exception {
  public:
   explicit TargetMismatch(const std::string& targetname)
       : Exception(targetname, "The target metadata in the Image and Director repos do not match.") {}
-  ~TargetMismatch() noexcept override = default;
 };
 
 class NonUniqueSignatures : public Exception {
  public:
   NonUniqueSignatures(const std::string& reponame, const std::string& role)
       : Exception(reponame, "The role " + role + " had non-unique signatures.") {}
-  ~NonUniqueSignatures() noexcept override = default;
 };
 
 class BadKeyId : public Exception {
  public:
-  BadKeyId(const std::string& reponame) : Exception(reponame, "A key has an incorrect associated key ID") {}
-  ~BadKeyId() noexcept override = default;
+  explicit BadKeyId(const std::string& reponame) : Exception(reponame, "A key has an incorrect associated key ID") {}
 };
 
 class BadEcuId : public Exception {
  public:
-  BadEcuId(const std::string& reponame)
+  explicit BadEcuId(const std::string& reponame)
       : Exception(reponame, "The target had an ECU ID that did not match the client's configured ECU ID.") {}
-  ~BadEcuId() noexcept override = default;
 };
 
 class BadHardwareId : public Exception {
  public:
-  BadHardwareId(const std::string& reponame)
+  explicit BadHardwareId(const std::string& reponame)
       : Exception(reponame, "The target had a hardware ID that did not match the client's configured hardware ID.") {}
-  ~BadHardwareId() noexcept override = default;
 };
 
 class RootRotationError : public Exception {
  public:
-  RootRotationError(const std::string& reponame)
+  explicit RootRotationError(const std::string& reponame)
       : Exception(reponame, "Version in Root metadata does not match its expected value.") {}
-  ~RootRotationError() noexcept override = default;
 };
 
 class VersionMismatch : public Exception {
  public:
   VersionMismatch(const std::string& reponame, const std::string& role)
       : Exception(reponame, "The version of role " + role + " does not match the entry in Snapshot metadata.") {}
-  ~VersionMismatch() noexcept override = default;
 };
 
 class DelegationHashMismatch : public Exception {
@@ -138,21 +120,18 @@ class DelegationHashMismatch : public Exception {
   explicit DelegationHashMismatch(const std::string& delegation_name)
       : Exception("image", "The calculated hash of delegated role " + delegation_name +
                                " did not match the hash in the metadata.") {}
-  ~DelegationHashMismatch() noexcept override = default;
 };
 
 class DelegationMissing : public Exception {
  public:
   explicit DelegationMissing(const std::string& delegation_name)
       : Exception("image", "The delegated role " + delegation_name + " is missing.") {}
-  ~DelegationMissing() noexcept override = default;
 };
 
 class InvalidTarget : public Exception {
  public:
   explicit InvalidTarget(const std::string& reponame)
       : Exception(reponame, "The target had a non-OSTree package that can not be installed on an OSTree system.") {}
-  ~InvalidTarget() noexcept override = default;
 };
 
 }  // namespace Uptane

--- a/src/libaktualizr/uptane/fetcher.h
+++ b/src/libaktualizr/uptane/fetcher.h
@@ -17,9 +17,9 @@ class IMetadataFetcher {
  public:
   IMetadataFetcher(const IMetadataFetcher&) = delete;
   IMetadataFetcher& operator=(const IMetadataFetcher&) = delete;
+  IMetadataFetcher& operator=(IMetadataFetcher&&) = delete;
   virtual ~IMetadataFetcher() = default;
 
- public:
   virtual void fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Uptane::Role& role,
                          Version version) const = 0;
   virtual void fetchLatestRole(std::string* result, int64_t maxsize, RepositoryType repo,

--- a/src/libaktualizr/uptane/manifest.h
+++ b/src/libaktualizr/uptane/manifest.h
@@ -14,7 +14,6 @@ class ManifestIssuer {
  public:
   using Ptr = std::shared_ptr<ManifestIssuer>;
 
- public:
   ManifestIssuer(std::shared_ptr<KeyManager> &key_mngr, Uptane::EcuSerial ecu_serial)
       : ecu_serial_(std::move(ecu_serial)), key_mngr_(key_mngr) {}
 

--- a/src/libaktualizr/uptane/root.cc
+++ b/src/libaktualizr/uptane/root.cc
@@ -10,7 +10,7 @@ Root::Root(const RepositoryType repo, const Json::Value &json, Root &root) : Roo
 }
 
 Root::Root(const RepositoryType repo, const Json::Value &json) : MetaWithKeys(json), policy_(Policy::kCheck) {
-  if (!json["signed"].isMember("keys")) {
+  if (!json["signed"].isMember("keys")) {  // NOLINT(bugprone-branch-clone)
     throw InvalidMetadata(repo, "root", "missing keys field");
   } else if (!json["signed"].isMember("roles")) {
     throw InvalidMetadata(repo, "root", "missing roles field");

--- a/src/libaktualizr/uptane/secondary_metadata.h
+++ b/src/libaktualizr/uptane/secondary_metadata.h
@@ -8,8 +8,7 @@ namespace Uptane {
 
 class SecondaryMetadata : public IMetadataFetcher {
  public:
-  SecondaryMetadata(MetaBundle meta_bundle_in);
-  SecondaryMetadata(SecondaryMetadata&&) = default;
+  explicit SecondaryMetadata(MetaBundle meta_bundle_in);
 
   void fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Role& role,
                  Version version) const override;

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -30,8 +30,9 @@ class RepositoryType {
   RepositoryType() = default;
   static constexpr int Director() { return static_cast<int>(Type::kDirector); }
   static constexpr int Image() { return static_cast<int>(Type::kImage); }
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
   RepositoryType(int type) { type_ = static_cast<RepositoryType::Type>(type); }
-  RepositoryType(const std::string &repo_type) {
+  explicit RepositoryType(const std::string &repo_type) {
     if (repo_type == DIRECTOR) {
       type_ = RepositoryType::Type::kDirector;
     } else if (repo_type == IMAGE) {
@@ -40,7 +41,9 @@ class RepositoryType {
       throw std::runtime_error(std::string("Incorrect repo type: ") + repo_type);
     }
   }
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
   operator int() const { return static_cast<int>(type_); }
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
   operator std::string() const { return ToString(); }
   Type type_;
   std::string ToString() const {
@@ -174,11 +177,12 @@ class MetaWithKeys : public BaseMeta {
    * delegations) and that implements TUF signature validation.
    * @param json - The contents of the 'signed' portion
    */
-  MetaWithKeys(const Json::Value &json);
+  explicit MetaWithKeys(const Json::Value &json);
   MetaWithKeys(RepositoryType repo, const Role &role, const Json::Value &json,
                const std::shared_ptr<MetaWithKeys> &signer);
 
   virtual ~MetaWithKeys() = default;
+  MetaWithKeys(const MetaWithKeys &guard) = default;
 
   void ParseKeys(RepositoryType repo, const Json::Value &keys);
   // role is the name of a role described in this object's metadata.
@@ -208,6 +212,10 @@ class MetaWithKeys : public BaseMeta {
   }
 
  protected:
+  MetaWithKeys(MetaWithKeys &&) = default;
+  MetaWithKeys &operator=(const MetaWithKeys &guard) = default;
+  MetaWithKeys &operator=(MetaWithKeys &&) = default;
+
   static const int64_t kMinSignatures = 1;
   static const int64_t kMaxSignatures = 1000;
 
@@ -230,8 +238,6 @@ class Root : public MetaWithKeys {
    */
   Root(RepositoryType repo, const Json::Value &json);
   Root(RepositoryType repo, const Json::Value &json, Root &root);
-
-  ~Root() override = default;
 
   /**
    * Take a JSON blob that contains a signatures/signed component that is supposedly for a given role, and check that is
@@ -277,7 +283,6 @@ class Targets : public MetaWithKeys {
   explicit Targets(const Json::Value &json);
   Targets(RepositoryType repo, const Role &role, const Json::Value &json, const std::shared_ptr<MetaWithKeys> &signer);
   Targets() = default;
-  ~Targets() override = default;
 
   bool operator==(const Targets &rhs) const {
     return version_ == rhs.version() && expiry_ == rhs.expiry() && MatchTargetVector(targets, rhs.targets);

--- a/src/libaktualizr/uptane/uptanerepository.h
+++ b/src/libaktualizr/uptane/uptanerepository.h
@@ -9,8 +9,13 @@ namespace Uptane {
 
 class RepositoryCommon {
  public:
+  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
   RepositoryCommon(RepositoryType type_in) : type{type_in} {}
   virtual ~RepositoryCommon() = default;
+  RepositoryCommon(const RepositoryCommon &guard) = default;
+  RepositoryCommon(RepositoryCommon &&) = default;
+  RepositoryCommon &operator=(const RepositoryCommon &guard) = default;
+  RepositoryCommon &operator=(RepositoryCommon &&) = default;
   void initRoot(RepositoryType repo_type, const std::string &root_raw);
   void verifyRoot(const std::string &root_raw);
   int rootVersion() const { return root.version(); }

--- a/src/libaktualizr/utilities/exceptions.h
+++ b/src/libaktualizr/utilities/exceptions.h
@@ -8,13 +8,11 @@
 class FatalException : public std::logic_error {
  public:
   explicit FatalException(const std::string &what_arg) : std::logic_error(what_arg.c_str()) { LOG_FATAL << what_arg; }
-  ~FatalException() noexcept override = default;
 };
 
 class NotImplementedException : public std::logic_error {
  public:
   NotImplementedException() : std::logic_error("Function not yet implemented.") {}
-  ~NotImplementedException() noexcept override = default;
 };
 
 #endif

--- a/src/libaktualizr/utilities/fault_injection.h
+++ b/src/libaktualizr/utilities/fault_injection.h
@@ -18,6 +18,8 @@
 #ifndef _FAULT_INJECTION_H
 #define _FAULT_INJECTION_H
 
+#include <string>
+
 /* Only define the stubs when fiu is disabled, otherwise use the real fiu.h
  * header */
 #ifndef FIU_ENABLE
@@ -30,16 +32,17 @@
 #define fiu_return_on(name, retval)
 
 // Note: was `#define fault_injection_last_info() ""` but it triggers
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static inline std::string fault_injection_last_info() { return ""; }
 
 #else
 
-#include <stdlib.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include <cstdlib>
 #include <fstream>
 #include <mutex>
-#include <string>
 
 #include <fiu-control.h>
 #include <fiu.h>
@@ -61,6 +64,7 @@ static inline const char *fault_injection_info_fn() {
   return info_fn.data();
 }
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static inline std::string fault_injection_last_info() {
   auto info_id = reinterpret_cast<uint64_t>(fiu_failinfo());
 
@@ -90,6 +94,7 @@ static inline std::string fault_injection_last_info() {
 }
 
 // proxy for fiu_enable, with persisted failinfo (through a file)
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static inline int fault_injection_enable(const char *name, int failnum, const std::string &failinfo,
                                          unsigned int flags) {
   std::array<char, fault_injection_info_bs> arr{};
@@ -97,7 +102,7 @@ static inline int fault_injection_enable(const char *name, int failnum, const st
 
   size_t failinfo_id = 0;
 
-  if (failinfo != "") {
+  if (!failinfo.empty()) {
     std::ofstream f;
     f.exceptions(std::ifstream::failbit | std::ifstream::badbit);
 
@@ -115,6 +120,7 @@ static inline int fault_injection_enable(const char *name, int failnum, const st
 
 // proxy for fiu_init, but also explicitly clears the persisted failinfo, in
 // case it is lingering from a previous test case.
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static inline void fault_injection_init() {
   fiu_init(0);
   std::ofstream f;

--- a/src/libaktualizr/utilities/sig_handler.h
+++ b/src/libaktualizr/utilities/sig_handler.h
@@ -15,7 +15,9 @@ class SigHandler {
   static SigHandler& get();
 
   SigHandler(const SigHandler&) = delete;
+  SigHandler(SigHandler&&) = delete;
   SigHandler& operator=(const SigHandler&) = delete;
+  SigHandler& operator=(SigHandler&&) = delete;
 
   // set an handler for signals and start the handling thread
   void start(const std::function<void()>& on_signal);

--- a/src/libaktualizr/utilities/timer.h
+++ b/src/libaktualizr/utilities/timer.h
@@ -10,10 +10,13 @@
 class Timer {
  public:
   Timer();
-  Timer(const Timer&) = delete;
-  Timer& operator=(const Timer&) = delete;
+  ~Timer() = default;
+  Timer(const Timer &) = delete;
+  Timer(Timer &&) = delete;
+  Timer &operator=(const Timer &) = delete;
+  Timer &operator=(Timer &&) = delete;
   bool RunningMoreThan(double seconds) const;
-  friend std::ostream& operator<<(std::ostream& os, const Timer& /*timer*/);
+  friend std::ostream &operator<<(std::ostream &os, const Timer &timer);
 
  private:
   using Clock = std::chrono::steady_clock;

--- a/src/libaktualizr/utilities/utils.cc
+++ b/src/libaktualizr/utilities/utils.cc
@@ -828,9 +828,9 @@ CURL *Utils::curlDupHandleWrapper(CURL *const curl_in, const bool using_pkcs11) 
 class SafeTempRoot {
  public:
   SafeTempRoot(const SafeTempRoot &) = delete;
-  SafeTempRoot(const SafeTempRoot &&) = delete;
+  SafeTempRoot(SafeTempRoot &&) = delete;
   SafeTempRoot operator=(const SafeTempRoot &) = delete;
-  SafeTempRoot operator=(const SafeTempRoot &&) = delete;
+  SafeTempRoot operator=(SafeTempRoot &&) = delete;
   // provide this as a static method so that we can use C++ static destructor
   // to remove the temp root
   static boost::filesystem::path &Get() {

--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -68,9 +68,11 @@ struct Utils {
 class TemporaryFile {
  public:
   explicit TemporaryFile(const std::string &hint = "file");
-  TemporaryFile(const TemporaryFile &) = delete;
-  TemporaryFile operator=(const TemporaryFile &) = delete;
   ~TemporaryFile();
+  TemporaryFile(const TemporaryFile &guard) = delete;
+  TemporaryFile(TemporaryFile &&) = delete;
+  TemporaryFile &operator=(const TemporaryFile &guard) = delete;
+  TemporaryFile &operator=(TemporaryFile &&) = delete;
   void PutContents(const std::string &contents) const;
   boost::filesystem::path Path() const;
   std::string PathString() const;
@@ -82,9 +84,11 @@ class TemporaryFile {
 class TemporaryDirectory {
  public:
   explicit TemporaryDirectory(const std::string &hint = "dir");
-  TemporaryDirectory(const TemporaryDirectory &) = delete;
-  TemporaryDirectory operator=(TemporaryDirectory &) = delete;
   ~TemporaryDirectory();
+  TemporaryDirectory(const TemporaryDirectory &guard) = delete;
+  TemporaryDirectory(TemporaryDirectory &&) = delete;
+  TemporaryDirectory &operator=(const TemporaryDirectory &guard) = delete;
+  TemporaryDirectory &operator=(TemporaryDirectory &&) = delete;
   boost::filesystem::path Path() const;
   std::string PathString() const;
   boost::filesystem::path operator/(const boost::filesystem::path &subdir) const;
@@ -105,11 +109,12 @@ using StructGuardInt = std::unique_ptr<T, int (*)(T *)>;
 class Socket {
  public:
   Socket();
-  Socket(int fd) : socket_fd_(fd) {}
+  explicit Socket(int fd) : socket_fd_(fd) {}
   virtual ~Socket();
-
-  Socket(const Socket &) = delete;
-  Socket &operator=(const Socket &) = delete;
+  Socket(const Socket &guard) = delete;
+  Socket(Socket &&) = delete;
+  Socket &operator=(const Socket &guard) = delete;
+  Socket &operator=(Socket &&) = delete;
 
   int &operator*() { return socket_fd_; }
   std::string ToString() const;
@@ -117,7 +122,6 @@ class Socket {
  protected:
   void bind(in_port_t port, bool reuse = true) const;
 
- protected:
   int socket_fd_;
 };
 
@@ -125,8 +129,11 @@ class ConnectionSocket : public Socket {
  public:
   ConnectionSocket(const std::string &ip, in_port_t port, in_port_t bind_port = 0);
   ~ConnectionSocket() override;
+  ConnectionSocket(const ConnectionSocket &guard) = delete;
+  ConnectionSocket(ConnectionSocket &&) = delete;
+  ConnectionSocket &operator=(const ConnectionSocket &guard) = delete;
+  ConnectionSocket &operator=(ConnectionSocket &&) = delete;
 
- public:
   int connect();
 
  private:
@@ -135,7 +142,7 @@ class ConnectionSocket : public Socket {
 
 class ListenSocket : public Socket {
  public:
-  ListenSocket(in_port_t port);
+  explicit ListenSocket(in_port_t port);
   in_port_t port() const { return _port; }
 
  private:
@@ -147,6 +154,10 @@ class CurlEasyWrapper {
  public:
   CurlEasyWrapper();
   ~CurlEasyWrapper();
+  CurlEasyWrapper(const CurlEasyWrapper &guard) = delete;
+  CurlEasyWrapper(CurlEasyWrapper &&) = delete;
+  CurlEasyWrapper &operator=(const CurlEasyWrapper &guard) = delete;
+  CurlEasyWrapper &operator=(CurlEasyWrapper &&) = delete;
   CURL *get() { return handle; }
 
  private:

--- a/src/libaktualizr/utilities/xml2json.h
+++ b/src/libaktualizr/utilities/xml2json.h
@@ -8,7 +8,7 @@
 namespace xml2json {
 
 static inline void addSubArray(Json::Value &d, const std::string &key, const Json::Value &arr) {
-  if (arr.size() == 0) {
+  if (arr.empty()) {
     return;
   } else if (arr.size() == 1) {
     d[key] = arr[0];
@@ -48,7 +48,7 @@ static inline Json::Value treeJson(const boost::property_tree::ptree &tree, int 
       continue;
     }
 
-    if (cur.key == "") {
+    if (cur.key.empty()) {
       cur.key = val;
     } else if (cur.key != val) {
       addSubArray(output, cur.key, cur.list);
@@ -59,13 +59,13 @@ static inline Json::Value treeJson(const boost::property_tree::ptree &tree, int 
     cur.list.append(treeJson(subtree, depth + 1));
   }
 
-  if (cur.key != "") {
+  if (!cur.key.empty()) {
     addSubArray(output, cur.key, cur.list);
   }
 
   {
     auto val = tree.get_value_optional<std::string>();
-    if (!!val && val.get() != "") {
+    if (!!val && !val.get().empty()) {
       if (leaf) {
         // <e>c</e> -> { "e": "c" }
         return val.get();
@@ -79,6 +79,7 @@ static inline Json::Value treeJson(const boost::property_tree::ptree &tree, int 
   return output;
 }
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static inline Json::Value xml2json(std::istream &is) {
   namespace bpt = boost::property_tree;
 

--- a/src/sota_tools/ostree_dir_repo.h
+++ b/src/sota_tools/ostree_dir_repo.h
@@ -13,7 +13,7 @@ class OSTreeDirRepo : public OSTreeRepo {
   OSTreeDirRepo(const OSTreeDirRepo&) = delete;
   OSTreeDirRepo(OSTreeDirRepo&&) = delete;
   OSTreeDirRepo& operator=(const OSTreeDirRepo&) = delete;
-  OSTreeDirRepo& operator=(const OSTreeDirRepo&&) = delete;
+  OSTreeDirRepo& operator=(OSTreeDirRepo&&) = delete;
   ~OSTreeDirRepo() override = default;
 
   bool LooksValid() const override;

--- a/src/sota_tools/ostree_hash.h
+++ b/src/sota_tools/ostree_hash.h
@@ -15,7 +15,8 @@ class OSTreeHash {
    */
   static OSTreeHash Parse(const std::string& hash);
 
-  explicit OSTreeHash(const uint8_t hash[32]);  // NOLINT(modernize-avoid-c-arrays)
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays, hicpp-avoid-c-arrays)
+  explicit OSTreeHash(const uint8_t hash[32]);
   explicit OSTreeHash(const std::array<uint8_t, 32>& hash);
 
   std::string string() const;

--- a/src/sota_tools/ostree_http_repo.h
+++ b/src/sota_tools/ostree_http_repo.h
@@ -11,8 +11,8 @@
 
 class OSTreeHttpRepo : public OSTreeRepo {
  public:
-  explicit OSTreeHttpRepo(TreehubServer* server, const boost::filesystem::path& root_in = "")
-      : server_(server), root_(root_in) {
+  explicit OSTreeHttpRepo(TreehubServer* server, boost::filesystem::path root_in = "")
+      : server_(server), root_(std::move(root_in)) {
     if (root_.empty()) {
       root_ = root_tmp_.Path();
     }
@@ -20,7 +20,6 @@ class OSTreeHttpRepo : public OSTreeRepo {
     curlEasySetoptWrapper(easy_handle_.get(), CURLOPT_WRITEFUNCTION, &OSTreeHttpRepo::curl_handle_write);
     curlEasySetoptWrapper(easy_handle_.get(), CURLOPT_FAILONERROR, true);
   }
-  ~OSTreeHttpRepo() override = default;
 
   bool LooksValid() const override;
   OSTreeRef GetRef(const std::string& refname) const override;

--- a/src/sota_tools/ostree_object.h
+++ b/src/sota_tools/ostree_object.h
@@ -40,9 +40,9 @@ class OSTreeObject {
   using ptr = boost::intrusive_ptr<OSTreeObject>;
   OSTreeObject(const OSTreeRepo& repo, OSTreeHash hash, OstreeObjectType object_type);
   OSTreeObject(const OSTreeObject&) = delete;
+  OSTreeObject(OSTreeObject&&) = delete;
   OSTreeObject operator=(const OSTreeObject&) = delete;
-  OSTreeObject(const OSTreeObject&&) = delete;
-  OSTreeObject operator=(const OSTreeObject&&) = delete;
+  OSTreeObject operator=(OSTreeObject&&) = delete;
 
   ~OSTreeObject();
 

--- a/src/sota_tools/ostree_ref.h
+++ b/src/sota_tools/ostree_ref.h
@@ -14,7 +14,6 @@ class OSTreeRef {
  public:
   OSTreeRef(const OSTreeRepo& repo, const std::string& ref_name);
   OSTreeRef(const TreehubServer& serve_repo, std::string ref_name);
-  OSTreeRef(OSTreeRef&& rhs) = default;
 
   void PushRef(const TreehubServer& push_target, CURL* curl_handle) const;
 
@@ -33,5 +32,5 @@ class OSTreeRef {
   static size_t curl_handle_write(void* buffer, size_t size, size_t nmemb, void* userp);
 };
 
-// vim: set tabstop=2 shiftwidth=2 expandtab:
 #endif  // SOTA_CLIENT_TOOLS_OSTREE_REF_H_
+// vim: set tabstop=2 shiftwidth=2 expandtab:

--- a/src/sota_tools/ostree_repo.h
+++ b/src/sota_tools/ostree_repo.h
@@ -32,7 +32,7 @@ class OSTreeRepo {
   virtual OSTreeRef GetRef(const std::string& refname) const = 0;
 
   OSTreeObject::ptr GetObject(OSTreeHash hash, OstreeObjectType type) const;
-  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays, hicpp-avoid-c-arrays)
   OSTreeObject::ptr GetObject(const uint8_t sha256[32], OstreeObjectType type) const;
 
   static boost::filesystem::path GetPathForHash(OSTreeHash hash, OstreeObjectType type);

--- a/src/sota_tools/rate_controller.h
+++ b/src/sota_tools/rate_controller.h
@@ -17,8 +17,11 @@ class RateController {
  public:
   using clock = std::chrono::steady_clock;
   explicit RateController(int concurrency_cap = 30);
+  ~RateController() = default;
   RateController(const RateController&) = delete;
+  RateController(RateController&&) = delete;
   RateController operator=(const RateController&) = delete;
+  RateController operator=(RateController&&) = delete;
 
   void RequestCompleted(clock::time_point start_time, clock::time_point end_time, bool succeeded);
 

--- a/src/uptane_generator/image_repo.h
+++ b/src/uptane_generator/image_repo.h
@@ -8,10 +8,10 @@ class ImageRepo : public Repo {
   ImageRepo(boost::filesystem::path path, const std::string &expires, std::string correlation_id)
       : Repo(Uptane::RepositoryType::Image(), std::move(path), expires, std::move(correlation_id)) {}
   void addBinaryImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
-                      const std::string &hardware_id, const std::string &url = "", const int32_t custom_version = 0,
+                      const std::string &hardware_id, const std::string &url = "", int32_t custom_version = 0,
                       const Delegation &delegation = {});
   void addCustomImage(const std::string &name, const Hash &hash, uint64_t length, const std::string &hardware_id,
-                      const std::string &url = "", const int32_t custom_version = 0, const Delegation &delegation = {},
+                      const std::string &url = "", int32_t custom_version = 0, const Delegation &delegation = {},
                       const Json::Value &custom = {});
   void addDelegation(const Uptane::Role &name, const Uptane::Role &parent_role, const std::string &path,
                      bool terminating, KeyType key_type);

--- a/src/uptane_generator/repo.h
+++ b/src/uptane_generator/repo.h
@@ -22,7 +22,7 @@ struct Delegation {
   bool isMatched(const boost::filesystem::path &image_path) const {
     return (fnmatch(pattern.c_str(), image_path.c_str(), 0) == 0);
   }
-  operator bool() const { return (!name.empty() && !pattern.empty()); }
+  explicit operator bool() const { return (!name.empty() && !pattern.empty()); }
   std::string name;
   std::string pattern;
 

--- a/src/uptane_generator/uptane_repo.h
+++ b/src/uptane_generator/uptane_repo.h
@@ -11,10 +11,10 @@ class UptaneRepo {
   void addTarget(const std::string &target_name, const std::string &hardware_id, const std::string &ecu_serial,
                  const std::string &url, const std::string &expires = "");
   void addImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
-                const std::string &hardware_id, const std::string &url = "", const int32_t custom_version = 0,
+                const std::string &hardware_id, const std::string &url = "", int32_t custom_version = 0,
                 const Delegation &delegation = {});
   void addCustomImage(const std::string &name, const Hash &hash, uint64_t length, const std::string &hardware_id,
-                      const std::string &url = "", const int32_t custom_version = 0, const Delegation &delegation = {},
+                      const std::string &url = "", int32_t custom_version = 0, const Delegation &delegation = {},
                       const Json::Value &custom = {});
   void addDelegation(const Uptane::Role &name, const Uptane::Role &parent_role, const std::string &path,
                      bool terminating, KeyType key_type);

--- a/src/virtual_secondary/managedsecondary.h
+++ b/src/virtual_secondary/managedsecondary.h
@@ -24,12 +24,8 @@ namespace Primary {
 
 class ManagedSecondaryConfig : public SecondaryConfig {
  public:
-  ManagedSecondaryConfig(const char* type = Type) : SecondaryConfig(type) {}
+  explicit ManagedSecondaryConfig(const std::string& type = "managed") : SecondaryConfig(type) {}
 
- public:
-  constexpr static const char* const Type = "managed";
-
- public:
   bool partial_verifying{false};
   std::string ecu_serial;
   std::string ecu_hardware_id;
@@ -50,6 +46,8 @@ class ManagedSecondary : public SecondaryInterface {
   explicit ManagedSecondary(Primary::ManagedSecondaryConfig sconfig_in);
   // Prevent inlining to enable forward declarations.
   ~ManagedSecondary() override;
+  ManagedSecondary(const ManagedSecondary&) = delete;
+  ManagedSecondary& operator=(const ManagedSecondary&) = delete;
 
   void init(std::shared_ptr<SecondaryProvider> secondary_provider_in) override {
     secondary_provider_ = std::move(secondary_provider_in);
@@ -75,6 +73,9 @@ class ManagedSecondary : public SecondaryInterface {
   bool loadKeys(std::string* pub_key, std::string* priv_key);
 
  protected:
+  ManagedSecondary(ManagedSecondary&&) = default;
+  ManagedSecondary& operator=(ManagedSecondary&&) = default;
+
   virtual bool getFirmwareInfo(Uptane::InstalledImageInfo& firmware_info) const;
 
   std::shared_ptr<SecondaryProvider> secondary_provider_;

--- a/src/virtual_secondary/virtualsecondary.cc
+++ b/src/virtual_secondary/virtualsecondary.cc
@@ -1,6 +1,7 @@
+#include <fstream>
+
 #include <boost/algorithm/hex.hpp>
 #include <boost/filesystem.hpp>
-#include <fstream>
 
 #include "crypto/crypto.h"
 #include "utilities/fault_injection.h"
@@ -9,7 +10,7 @@
 
 namespace Primary {
 
-const char* const VirtualSecondaryConfig::Type = "virtual";
+constexpr const char* const VirtualSecondaryConfig::Type;
 
 VirtualSecondaryConfig::VirtualSecondaryConfig(const Json::Value& json_config) : ManagedSecondaryConfig(Type) {
   partial_verifying = json_config["partial_verifying"].asBool();

--- a/src/virtual_secondary/virtualsecondary.h
+++ b/src/virtual_secondary/virtualsecondary.h
@@ -10,7 +10,7 @@ namespace Primary {
 
 class VirtualSecondaryConfig : public ManagedSecondaryConfig {
  public:
-  static const char* const Type;
+  static constexpr const char* const Type{"virtual"};
 
   VirtualSecondaryConfig() : ManagedSecondaryConfig(Type) {}
   explicit VirtualSecondaryConfig(const Json::Value& json_config);
@@ -22,7 +22,6 @@ class VirtualSecondaryConfig : public ManagedSecondaryConfig {
 class VirtualSecondary : public ManagedSecondary {
  public:
   explicit VirtualSecondary(Primary::VirtualSecondaryConfig sconfig_in);
-  ~VirtualSecondary() override = default;
 
   std::string Type() const override { return VirtualSecondaryConfig::Type; }
   data::InstallationResult putMetadata(const Uptane::Target& target) override;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,16 +112,19 @@ if(SOTA_PACKED_CREDENTIALS)
         set_tests_properties(device_cred_prov_hsm_test PROPERTIES LABELS "credentials")
     endif(BUILD_P11 AND TEST_PKCS11_MODULE_PATH)
 
-    # do not link tests with libaktualizr, but sota_tools_lib
-    list(REMOVE_ITEM TEST_LIBS aktualizr_lib)
-    list(INSERT TEST_LIBS 0 sota_tools_lib)
-    add_aktualizr_test(NAME sota_tools_auth_cred_test
-                        SOURCES authenticate_cred_test.cc
-                        PROJECT_WORKING_DIRECTORY
-                        ARGS ${SOTA_PACKED_CREDENTIALS})
-    add_dependencies(t_sota_tools_auth_cred_test t_sota_tools_auth_test)
-    target_include_directories(t_sota_tools_auth_cred_test PUBLIC ${PROJECT_SOURCE_DIR}/tests ${PROJECT_SOURCE_DIR}/src/sota_tools)
-    set_tests_properties(test_sota_tools_auth_cred_test PROPERTIES LABELS "credentials")
+    if(BUILD_SOTA_TOOLS)
+        # do not link this test with libaktualizr, but rather with sota_tools_lib
+        list(REMOVE_ITEM TEST_LIBS aktualizr_lib)
+        list(INSERT TEST_LIBS 0 sota_tools_lib)
+        add_aktualizr_test(NAME sota_tools_auth_cred_test
+                           SOURCES authenticate_cred_test.cc
+                           PROJECT_WORKING_DIRECTORY
+                           ARGS ${SOTA_PACKED_CREDENTIALS})
+        add_dependencies(t_sota_tools_auth_cred_test t_sota_tools_auth_test)
+        target_include_directories(t_sota_tools_auth_cred_test PUBLIC
+                                   ${PROJECT_SOURCE_DIR}/tests ${PROJECT_SOURCE_DIR}/src/sota_tools)
+        set_tests_properties(test_sota_tools_auth_cred_test PROPERTIES LABELS "credentials")
+    endif(BUILD_SOTA_TOOLS)
 endif(SOTA_PACKED_CREDENTIALS)
 
 ###############################################################################


### PR DESCRIPTION
Mostly pretty basic stuff, but a few things required some finesse to make each compiler with every variation of the build options happy.