### PR TITLE
Make sota tools dependent just on libostree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,10 @@ if(BUILD_OSTREE)
     find_package(OSTree REQUIRED)
     add_definitions(-DBUILD_OSTREE)
 else(BUILD_OSTREE)
-    unset(LIBOSTREE_LIBRARIES CACHE)
+    # The sota tools depend on libostree so no reason to unset LIBOSTREE_LIBRARIES if they are enabled
+    if (NOT BUILD_SOTA_TOOLS)
+        unset(LIBOSTREE_LIBRARIES CACHE)
+    endif(NOT BUILD_SOTA_TOOLS)
 endif(BUILD_OSTREE)
 
 if(BUILD_P11)
@@ -138,10 +141,8 @@ endif(BUILD_P11)
 if(BUILD_SOTA_TOOLS)
     find_package(GLIB2 REQUIRED)
     find_program(STRACE NAMES strace)
-
-    if (NOT BUILD_OSTREE)
-        message(SEND_ERROR "BUILD_SOTA_TOOLS requires BUILD_OSTREE to be enabled")
-    endif()
+    # The sota tools depend on libostree, but they don't require/depend on software enabled by BUILD_OSTREE flag
+    find_package(OSTree REQUIRED)
 endif(BUILD_SOTA_TOOLS)
 
 if(FAULT_INJECTION)

--- a/include/libaktualizr/config.h
+++ b/include/libaktualizr/config.h
@@ -150,7 +150,7 @@ struct TelemetryConfig {
   void writeToStream(std::ostream& out_stream) const;
 };
 
-enum class RollbackMode { kBootloaderNone = 0, kUbootGeneric, kUbootMasked };
+enum class RollbackMode { kBootloaderNone = 0, kUbootGeneric, kUbootMasked, kFioVB };
 std::ostream& operator<<(std::ostream& os, RollbackMode mode);
 
 struct BootloaderConfig {
@@ -197,7 +197,6 @@ class BaseConfig {
 
   std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
                                                        "/etc/sota/conf.d/"};
-
 };
 
 /**

--- a/include/libaktualizr/config.h
+++ b/include/libaktualizr/config.h
@@ -64,7 +64,7 @@ struct ProvisionConfig {
 };
 
 struct UptaneConfig {
-  uint64_t polling_sec{10U};
+  uint64_t polling_sec{300U};
   std::string director_server;
   std::string repo_server;
   CryptoSource key_source{CryptoSource::kFile};
@@ -195,7 +195,9 @@ class BaseConfig {
     }
   }
 
-  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
+  std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/var/sota/sota.toml",
+                                                       "/etc/sota/conf.d/"};
+
 };
 
 /**

--- a/include/libaktualizr/packagemanagerinterface.h
+++ b/include/libaktualizr/packagemanagerinterface.h
@@ -54,6 +54,7 @@ class PackageManagerInterface {
   virtual void completeInstall() const { throw std::runtime_error("Unimplemented"); }
   virtual data::InstallationResult finalizeInstall(const Uptane::Target& target) = 0;
   virtual void updateNotify() {}
+  virtual void installNotify(const Uptane::Target& target) { (void)target; }
   virtual bool fetchTarget(const Uptane::Target& target, Uptane::Fetcher& fetcher, const KeyManager& keys,
                            const FetcherProgressCb& progress_cb, const api::FlowControlToken* token);
   virtual TargetStatus verifyTarget(const Uptane::Target& target) const;

--- a/scripts/clang-tidy-wrapper.sh
+++ b/scripts/clang-tidy-wrapper.sh
@@ -15,7 +15,9 @@ fi
 # Filter out anything that we aren't trying to compile. Older clang-tidy
 # versions (<=6) skipped them automatically.
 if grep -q "${FILE}" "${CMAKE_BINARY_DIR}/compile_commands.json"; then
-  ${CLANG_TIDY} -quiet -header-filter="\(${CMAKE_SOURCE_DIR}|\\.\\.\)/src/.*" --extra-arg-before=-Wno-unknown-warning-option -format-style=file -p "${CMAKE_BINARY_DIR}" "${FILE}"
+  ${CLANG_TIDY} -quiet -header-filter="\(${CMAKE_SOURCE_DIR}|\\.\\.\)/src/.*" --extra-arg-before=-Wno-unknown-warning-option -format-style=file \
+    --checks=-clang-analyzer-cplusplus.NewDeleteLeaks,-clang-analyzer-core.NonNullParamChecker \
+    -p "${CMAKE_BINARY_DIR}" "${FILE}"
 else
   echo "Skipping ${FILE}"
 fi

--- a/src/aktualizr_get/get.cc
+++ b/src/aktualizr_get/get.cc
@@ -3,8 +3,9 @@
 #include "http/httpclient.h"
 #include "storage/invstorage.h"
 
-std::string aktualizrGet(Config &config, const std::string &url, const std::vector<std::string> &headers) {
-  auto storage = INvStorage::newStorage(config.storage);
+std::string aktualizrGet(Config &config, const std::string &url, const std::vector<std::string> &headers,
+                         StorageClient storage_client) {
+  auto storage = INvStorage::newStorage(config.storage, false, storage_client);
   storage->importData(config.import);
 
   auto client = std_::make_unique<HttpClient>(&headers);

--- a/src/aktualizr_get/get.h
+++ b/src/aktualizr_get/get.h
@@ -2,7 +2,9 @@
 #define AKTUALIZR_GET_HELPERS
 
 #include "libaktualizr/config.h"
+#include "storage/invstorage.h"
 
-std::string aktualizrGet(Config &config, const std::string &url, const std::vector<std::string> &headers);
+std::string aktualizrGet(Config &config, const std::string &url, const std::vector<std::string> &headers,
+                         StorageClient storage_client = StorageClient::kUptane);
 
 #endif  // AKTUALIZR_GET_HELPERS

--- a/src/libaktualizr/bootloader/bootloader.cc
+++ b/src/libaktualizr/bootloader/bootloader.cc
@@ -46,6 +46,9 @@ void Bootloader::setBootOK() const {
       if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
         LOG_WARNING << "Failed resetting bootcount";
       }
+      if (Utils::shell("fiovb_setenv upgrade_available 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting upgrade_available";
+      }
       break;
     default:
       throw NotImplementedException();
@@ -79,6 +82,9 @@ void Bootloader::updateNotify() const {
     case RollbackMode::kFioVB:
       if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
         LOG_WARNING << "Failed resetting bootcount";
+      }
+      if (Utils::shell("fiovb_setenv upgrade_available 1", &sink) != 0) {
+        LOG_WARNING << "Failed setting upgrade_available";
       }
       if (Utils::shell("fiovb_setenv rollback 0", &sink) != 0) {
         LOG_WARNING << "Failed resetting rollback flag";

--- a/src/libaktualizr/bootloader/bootloader.cc
+++ b/src/libaktualizr/bootloader/bootloader.cc
@@ -42,6 +42,11 @@ void Bootloader::setBootOK() const {
         LOG_WARNING << "Failed resetting upgrade_available for u-boot";
       }
       break;
+    case RollbackMode::kFioVB:
+      if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting bootcount";
+      }
+      break;
     default:
       throw NotImplementedException();
   }
@@ -68,6 +73,14 @@ void Bootloader::updateNotify() const {
         LOG_WARNING << "Failed setting upgrade_available for u-boot";
       }
       if (Utils::shell("fw_setenv rollback 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting rollback flag";
+      }
+      break;
+    case RollbackMode::kFioVB:
+      if (Utils::shell("fiovb_setenv bootcount 0", &sink) != 0) {
+        LOG_WARNING << "Failed resetting bootcount";
+      }
+      if (Utils::shell("fiovb_setenv rollback 0", &sink) != 0) {
         LOG_WARNING << "Failed resetting rollback flag";
       }
       break;

--- a/src/libaktualizr/bootloader/bootloader.h
+++ b/src/libaktualizr/bootloader/bootloader.h
@@ -11,6 +11,7 @@ class Bootloader {
   virtual ~Bootloader() {}
   virtual void setBootOK() const;
   virtual void updateNotify() const;
+  virtual void installNotify(const Uptane::Target& target) const { (void)target; }
 
   // Reboot handling (uses storage)
   //

--- a/src/libaktualizr/bootloader/bootloader_config.cc
+++ b/src/libaktualizr/bootloader/bootloader_config.cc
@@ -10,6 +10,9 @@ std::ostream& operator<<(std::ostream& os, RollbackMode mode) {
     case RollbackMode::kUbootMasked:
       mode_s = "uboot_masked";
       break;
+    case RollbackMode::kFioVB:
+      mode_s = "fiovb";
+      break;
     default:
       mode_s = "none";
       break;
@@ -27,6 +30,8 @@ inline void CopyFromConfig(RollbackMode& dest, const std::string& option_name, c
       dest = RollbackMode::kUbootGeneric;
     } else if (mode == "uboot_masked") {
       dest = RollbackMode::kUbootMasked;
+    } else if (mode == "fiovb") {
+      dest = RollbackMode::kFioVB;
     } else {
       dest = RollbackMode::kBootloaderNone;
     }

--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -258,6 +258,7 @@ data::InstallationResult OstreeManager::finalizeInstall(const Uptane::Target &ta
 }
 
 void OstreeManager::updateNotify() { bootloader_->updateNotify(); }
+void OstreeManager::installNotify(const Uptane::Target &target) { bootloader_->installNotify(target); }
 
 OstreeManager::OstreeManager(const PackageConfig &pconfig, const BootloaderConfig &bconfig,
                              const std::shared_ptr<INvStorage> &storage, const std::shared_ptr<HttpInterface> &http,

--- a/src/libaktualizr/package_manager/ostreemanager.h
+++ b/src/libaktualizr/package_manager/ostreemanager.h
@@ -54,6 +54,7 @@ class OstreeManager : public PackageManagerInterface {
   void completeInstall() const override;
   data::InstallationResult finalizeInstall(const Uptane::Target &target) override;
   void updateNotify() override;
+  void installNotify(const Uptane::Target &target) override;
   bool fetchTarget(const Uptane::Target &target, Uptane::Fetcher &fetcher, const KeyManager &keys,
                    const FetcherProgressCb &progress_cb, const api::FlowControlToken *token) override;
   TargetStatus verifyTarget(const Uptane::Target &target) const override;

--- a/src/libaktualizr/storage/invstorage.cc
+++ b/src/libaktualizr/storage/invstorage.cc
@@ -147,7 +147,8 @@ void INvStorage::importData(const ImportConfig& import_config) {
   importInstalledVersions(import_config.base_path);
 }
 
-std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, const bool readonly, StorageClient client) {
+std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, const bool readonly,
+                                                   StorageClient client) {
   switch (config.type) {
     case StorageType::kSqlite: {
       boost::filesystem::path db_path = config.sqldb_path.get(config.path);

--- a/src/libaktualizr/storage/invstorage.cc
+++ b/src/libaktualizr/storage/invstorage.cc
@@ -91,6 +91,10 @@ void INvStorage::importUpdateCertificate(const boost::filesystem::path& base_pat
 
 void INvStorage::importPrimaryKeys(const boost::filesystem::path& base_path, const utils::BasedPath& import_pubkey_path,
                                    const utils::BasedPath& import_privkey_path) {
+  if (client_ == StorageClient::kTUF) {
+    LOG_DEBUG << "TUF instance, primary keys not required";
+    return;
+  }
   if (import_pubkey_path.empty() || import_privkey_path.empty()) {
     LOG_ERROR << "Couldn`t import data: empty path received";
     return;
@@ -143,7 +147,7 @@ void INvStorage::importData(const ImportConfig& import_config) {
   importInstalledVersions(import_config.base_path);
 }
 
-std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, const bool readonly) {
+std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, const bool readonly, StorageClient client) {
   switch (config.type) {
     case StorageType::kSqlite: {
       boost::filesystem::path db_path = config.sqldb_path.get(config.path);
@@ -162,7 +166,7 @@ std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, 
         old_config.type = StorageType::kFileSystem;
         old_config.path = config.path;
 
-        auto sql_storage = std::make_shared<SQLStorage>(config, readonly);
+        auto sql_storage = std::make_shared<SQLStorage>(config, readonly, client);
         FSStorageRead fs_storage(old_config);
         INvStorage::FSSToSQLS(fs_storage, *sql_storage);
         return sql_storage;
@@ -172,7 +176,7 @@ std::shared_ptr<INvStorage> INvStorage::newStorage(const StorageConfig& config, 
       } else {
         LOG_INFO << "Use existing SQL storage: " << db_path;
       }
-      return std::make_shared<SQLStorage>(config, readonly);
+      return std::make_shared<SQLStorage>(config, readonly, client);
     }
     case StorageType::kFileSystem:
     default:

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -44,7 +44,8 @@ enum class InstalledVersionUpdateMode { kNone, kCurrent, kPending };
 // store* functions normally write the complete content. save* functions just add an entry.
 class INvStorage {
  public:
-  explicit INvStorage(StorageConfig config, StorageClient client = StorageClient::kUptane): config_(std::move(config)), client_(client) { }
+  explicit INvStorage(StorageConfig config, StorageClient client = StorageClient::kUptane)
+      : config_(std::move(config)), client_(client) {}
   virtual ~INvStorage() = default;
   virtual StorageType type() = 0;
   virtual void storePrimaryKeys(const std::string& public_key, const std::string& private_key) = 0;
@@ -179,6 +180,7 @@ class INvStorage {
 
  protected:
   const StorageConfig config_;
+
  private:
   StorageClient client_;
 };

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -17,6 +17,8 @@ class INvStorage;
 class FSStorageRead;
 class SQLStorage;
 
+enum class StorageClient { kUptane = 0, kTUF = 1 };
+
 using store_data_t = void (INvStorage::*)(const std::string&);
 using load_data_t = bool (INvStorage::*)(std::string*) const;
 
@@ -42,7 +44,7 @@ enum class InstalledVersionUpdateMode { kNone, kCurrent, kPending };
 // store* functions normally write the complete content. save* functions just add an entry.
 class INvStorage {
  public:
-  explicit INvStorage(StorageConfig config) : config_(std::move(config)) {}
+  explicit INvStorage(StorageConfig config, StorageClient client = StorageClient::kUptane): config_(std::move(config)), client_(client) { }
   virtual ~INvStorage() = default;
   virtual StorageType type() = 0;
   virtual void storePrimaryKeys(const std::string& public_key, const std::string& private_key) = 0;
@@ -146,7 +148,8 @@ class INvStorage {
   virtual void cleanUp() = 0;
 
   // Special constructors and utilities
-  static std::shared_ptr<INvStorage> newStorage(const StorageConfig& config, bool readonly = false);
+  static std::shared_ptr<INvStorage> newStorage(const StorageConfig& config, bool readonly = false,
+                                                StorageClient client = StorageClient::kUptane);
   static void FSSToSQLS(FSStorageRead& fs_storage, SQLStorage& sql_storage);
   static bool fsReadInstalledVersions(const boost::filesystem::path& filename,
                                       std::vector<Uptane::Target>* installed_versions, size_t* current_version);
@@ -176,6 +179,8 @@ class INvStorage {
 
  protected:
   const StorageConfig config_;
+ private:
+  StorageClient client_;
 };
 
 #endif  // INVSTORAGE_H_

--- a/src/libaktualizr/storage/sqlstorage.cc
+++ b/src/libaktualizr/storage/sqlstorage.cc
@@ -58,11 +58,11 @@ void SQLStorage::cleanMetaVersion(Uptane::RepositoryType repo, const Uptane::Rol
   db.commitTransaction();
 }
 
-SQLStorage::SQLStorage(const StorageConfig& config, bool readonly)
+SQLStorage::SQLStorage(const StorageConfig& config, bool readonly, StorageClient storage_client)
     : SQLStorageBase(config.sqldb_path.get(config.path), readonly, libaktualizr_schema_migrations,
                      libaktualizr_schema_rollback_migrations, libaktualizr_current_schema,
                      libaktualizr_current_schema_version),
-      INvStorage(config) {
+      INvStorage(config, storage_client) {
   try {
     cleanMetaVersion(Uptane::RepositoryType::Director(), Uptane::Role::Root());
     cleanMetaVersion(Uptane::RepositoryType::Image(), Uptane::Role::Root());

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -19,7 +19,8 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
  public:
   friend class SQLTargetWHandle;
   friend class SQLTargetRHandle;
-  explicit SQLStorage(const StorageConfig& config, bool readonly, StorageClient storage_client = StorageClient::kUptane);
+  explicit SQLStorage(const StorageConfig& config, bool readonly,
+                      StorageClient storage_client = StorageClient::kUptane);
   ~SQLStorage() override = default;
   void storePrimaryKeys(const std::string& public_key, const std::string& private_key) override;
   bool loadPrimaryKeys(std::string* public_key, std::string* private_key) const override;

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -19,7 +19,7 @@ class SQLStorage : public SQLStorageBase, public INvStorage {
  public:
   friend class SQLTargetWHandle;
   friend class SQLTargetRHandle;
-  explicit SQLStorage(const StorageConfig& config, bool readonly);
+  explicit SQLStorage(const StorageConfig& config, bool readonly, StorageClient storage_client = StorageClient::kUptane);
   ~SQLStorage() override = default;
   void storePrimaryKeys(const std::string& public_key, const std::string& private_key) override;
   bool loadPrimaryKeys(std::string* public_key, std::string* private_key) const override;


### PR DESCRIPTION
Sota tools depends on libostree but they don't require any
software/components enabled by BUILD_OSTREE flag.
So, this change allows building sota tools with BUILD_OSTREE set to `OFF`.

Signed-off-by: Mike Sul <mike.sul@foundries.io>