### PR TITLE
Report correct OSTree hash when currently booted target is absent

### DIFF
--- a/include/libaktualizr/types.h
+++ b/include/libaktualizr/types.h
@@ -396,7 +396,8 @@ class Target {
   Target(std::string filename, const Json::Value &content);
   // Internal use only. Only used for reading installed_versions list and by
   // various tests.
-  Target(std::string filename, EcuMap ecus, std::vector<Hash> hashes, uint64_t length, std::string correlation_id = "");
+  Target(std::string filename, EcuMap ecus, std::vector<Hash> hashes, uint64_t length, std::string correlation_id = "",
+         std::string type = "UNKNOWN");
 
   static Target Unknown();
 

--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -398,8 +398,17 @@ Uptane::Target OstreeManager::getCurrent() const {
       return *it;
     }
   }
-
-  return Uptane::Target::Unknown();
+  // We haven't found a matching target. This can occur when a device is
+  // freshly manufactured and the factory image is in a delegated target.
+  // Aktualizr will have had no reason to fetch the relevant delegation, and it
+  // doesn't know where in the delegation tree on the server it might be.
+  // See https://github.com/uptane/aktualizr/issues/1 for more details. In this
+  // case attempt to construct an approximate Uptane target. By getting the
+  // hash correct the server has a chance to figure out what is running on the
+  // device.
+  Uptane::EcuMap ecus;
+  std::vector<Hash> hashes{Hash(Hash::Type::kSha256, current_hash)};
+  return {"unknown", ecus, hashes, 0, "", "OSTREE"};
 }
 
 // used for bootloader rollback

--- a/src/libaktualizr/package_manager/ostreemanager_test.cc
+++ b/src/libaktualizr/package_manager/ostreemanager_test.cc
@@ -1,11 +1,9 @@
 #include <gtest/gtest.h>
 
-#include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>
 
-#include <boost/algorithm/hex.hpp>
 #include <boost/filesystem.hpp>
 
 #include "libaktualizr/config.h"

--- a/src/libaktualizr/primary/sotauptaneclient.h
+++ b/src/libaktualizr/primary/sotauptaneclient.h
@@ -94,6 +94,7 @@ class SotaUptaneClient {
   FRIEND_TEST(UptaneKey, Check);  // Note hacky name
   FRIEND_TEST(UptaneNetwork, DownloadFailure);
   FRIEND_TEST(UptaneNetwork, LogConnectivityRestored);
+  FRIEND_TEST(UptaneOstree, InitialManifest);
   FRIEND_TEST(UptaneVector, Test);
   FRIEND_TEST(aktualizr_secondary_uptane, credentialsPassing);
   FRIEND_TEST(MetadataExpirationTest, MetadataExpirationAfterInstallationAndBeforeApplication);

--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -62,6 +62,19 @@ add_aktualizr_test(NAME uptane_serial SOURCES uptane_serial_test.cc
                    PROJECT_WORKING_DIRECTORY
                    LIBRARIES uptane_generator_lib virtual_secondary)
 
+if(BUILD_OSTREE)
+    # Test that SotaUptaneClient::AssembleManifest() works correctly under OSTree.
+    # This requires the OSTree sysroot created by make_ostree_sysroot in
+    # package_manager/CMakeLists.txt, which is run as a dependency of the
+    # build_tests target.
+    add_aktualizr_test(NAME uptane_ostree SOURCES uptane_ostree_test.cc
+                      PROJECT_WORKING_DIRECTORY
+                      ARGS ${PROJECT_BINARY_DIR}/ostree_repo
+                      LIBRARIES uptane_generator_lib virtual_secondary)
+else(BUILD_OSTREE)
+    list(APPEND TEST_SOURCES uptane_ostree_test.cc)
+endif(BUILD_OSTREE)
+
 add_aktualizr_test(NAME director SOURCES director_test.cc
                    PROJECT_WORKING_DIRECTORY
                    ARGS "$<TARGET_FILE:uptane-generator>")

--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -52,15 +52,18 @@ add_dependencies(t_uptane_delegation uptane-generator)
 target_link_libraries(t_uptane_delegation virtual_secondary)
 set_tests_properties(test_uptane_delegation PROPERTIES LABELS "crypto")
 
-add_aktualizr_test(NAME uptane_network SOURCES uptane_network_test.cc PROJECT_WORKING_DIRECTORY LIBRARIES uptane_generator_lib)
+add_aktualizr_test(NAME uptane_network
+                   SOURCES uptane_network_test.cc
+                   PROJECT_WORKING_DIRECTORY
+                   LIBRARIES uptane_generator_lib virtual_secondary)
 set_tests_properties(test_uptane_network PROPERTIES LABELS "crypto")
-target_link_libraries(t_uptane_network virtual_secondary)
 
 add_aktualizr_test(NAME uptane_serial SOURCES uptane_serial_test.cc
-                   PROJECT_WORKING_DIRECTORY LIBRARIES uptane_generator_lib)
-target_link_libraries(t_uptane_serial virtual_secondary)
+                   PROJECT_WORKING_DIRECTORY
+                   LIBRARIES uptane_generator_lib virtual_secondary)
 
-add_aktualizr_test(NAME director SOURCES director_test.cc PROJECT_WORKING_DIRECTORY
+add_aktualizr_test(NAME director SOURCES director_test.cc
+                   PROJECT_WORKING_DIRECTORY
                    ARGS "$<TARGET_FILE:uptane-generator>")
 
 aktualizr_source_file_checks(${SOURCES} ${HEADERS} ${TEST_SOURCES})

--- a/src/libaktualizr/uptane/tuf.cc
+++ b/src/libaktualizr/uptane/tuf.cc
@@ -126,15 +126,16 @@ void Target::updateCustom(const Json::Value &custom) {
 }
 
 // Internal use only.
-Target::Target(std::string filename, EcuMap ecus, std::vector<Hash> hashes, uint64_t length, std::string correlation_id)
+Target::Target(std::string filename, EcuMap ecus, std::vector<Hash> hashes, uint64_t length, std::string correlation_id,
+               std::string type)
     : filename_(std::move(filename)),
+      type_(std::move(type)),
       ecus_(std::move(ecus)),
       hashes_(std::move(hashes)),
       length_(length),
       correlation_id_(std::move(correlation_id)) {
   // sort hashes so that higher priority hash algorithm goes first
   std::sort(hashes_.begin(), hashes_.end(), [](const Hash &l, const Hash &r) { return l.type() < r.type(); });
-  type_ = "UNKNOWN";
 }
 
 Target Target::Unknown() {

--- a/src/libaktualizr/uptane/uptane_ostree_test.cc
+++ b/src/libaktualizr/uptane/uptane_ostree_test.cc
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+
+#include "httpfake.h"
+#include "libaktualizr/config.h"
+#include "package_manager/ostreemanager.h"
+#include "storage/invstorage.h"
+#include "uptane_test_common.h"
+#include "utilities/utils.h"
+
+boost::filesystem::path test_sysroot;
+
+TEST(UptaneOstree, InitialManifest) {
+  TemporaryDirectory temp_dir;
+  auto http = std::make_shared<HttpFake>(temp_dir.Path());
+  Config config("tests/config/basic.toml");
+  config.pacman.type = PACKAGE_MANAGER_OSTREE;
+  config.pacman.sysroot = test_sysroot;
+  config.storage.path = temp_dir.Path();
+  config.pacman.booted = BootedType::kStaged;
+  config.uptane.director_server = http->tls_server + "director";
+  config.uptane.repo_server = http->tls_server + "repo";
+  config.provision.primary_ecu_serial = "CA:FE:A6:D2:84:9D";
+  config.provision.primary_ecu_hardware_id = "primary_hw";
+
+  auto storage = INvStorage::newStorage(config.storage);
+  auto sota_client = std_::make_unique<UptaneTestCommon::TestUptaneClient>(config, storage, http);
+  EXPECT_NO_THROW(sota_client->initialize());
+  auto manifest = sota_client->AssembleManifest();
+  // Fish the sha256 hash out of the manifest
+  auto installed_image =
+      manifest["ecu_version_manifests"][config.provision.primary_ecu_serial]["signed"]["installed_image"];
+  std::string hash = installed_image["fileinfo"]["hashes"]["sha256"].asString();
+
+  // e3b0c442... is the sha256 hash of the empty string (i.e. echo -n | sha256sum)
+  EXPECT_NE(hash, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+      << "should not be the hash of the empty string";
+
+  OstreeManager ostree(config.pacman, config.bootloader, storage, nullptr);
+  EXPECT_EQ(hash, ostree.getCurrentHash());
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  if (argc != 2) {
+    std::cerr << "Error: " << argv[0] << " requires the path to an OSTree sysroot as an input argument.\n";
+    return EXIT_FAILURE;
+  }
+
+  TemporaryDirectory temp_sysroot;
+  test_sysroot = temp_sysroot / "sysroot";
+  // uses cp, as boost doesn't like to copy bad symlinks
+  int r = system((std::string("cp -r ") + argv[1] + std::string(" ") + test_sysroot.string()).c_str());
+  if (r != 0) {
+    return EXIT_FAILURE;
+  }
+
+  return RUN_ALL_TESTS();
+}
+#endif


### PR DESCRIPTION
This is a fix for https://github.com/uptane/aktualizr/issues/1 "Aktualizr reports incorrect OSTree hash if it doesn't find the currently-booting version in its targets"

@tkfu 