### PR TITLE
Fix flakey "test_aktualizr_kill" test

### DIFF
--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -9,18 +9,29 @@ import signal
 import socket
 import time
 
-from os import path
+from io import BytesIO
+from os import path, urandom
 from uuid import uuid4
-from os import urandom
 from functools import wraps
 from multiprocessing import pool, cpu_count
 from http.server import SimpleHTTPRequestHandler, HTTPServer
-
+from threading import Thread
 from fake_http_server.fake_test_server import FakeTestServerBackground
 from sota_tools.treehub_server import create_repo
+from shutil import copyfileobj
 
 
 logger = logging.getLogger(__name__)
+
+
+class CopyThread(Thread):
+    def __init__(self, src, dest):
+        super().__init__()
+        self._src = src
+        self._dst = dest
+
+    def run(self):
+        copyfileobj(self._src, self._dst, 1024)
 
 
 class Aktualizr:
@@ -247,19 +258,28 @@ class Aktualizr:
                                          stderr=None if self._output_logs else subprocess.STDOUT,
                                          close_fds=True,
                                          env=self._run_env)
+        if not self._output_logs:
+            self._stdout = BytesIO()
+            self._stdout_thread = CopyThread(self._process.stdout, self._stdout)
+            self._stdout_thread.start()
         logger.debug("Aktualizr has been started")
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._process.terminate()
         self._process.wait(timeout=60)
+        if not self._output_logs:
+            self._stdout_thread.join(10)
         logger.debug("Aktualizr has been stopped")
 
     def terminate(self, sig=signal.SIGTERM):
         self._process.send_signal(sig)
 
     def output(self):
-        return self._process.stdout.read().decode(errors='replace')
+        if self._output_logs:
+            # stdout has gone to the console...
+            raise Exception("Can't get output from Aktualizr object if output_logs is set")
+        return self._stdout.getbuffer().tobytes().decode(errors='replace')
 
     def wait_for_completion(self, timeout=120):
         self._process.wait(timeout)
@@ -388,13 +408,25 @@ class IPSecondary:
                                          stderr=None if self._output_logs else subprocess.STDOUT,
                                          close_fds=True,
                                          env=self._run_env)
+        if not self._output_logs:
+            self._stdout = BytesIO()
+            self._stdout_thread = CopyThread(self._process.stdout, self._stdout)
+            self._stdout_thread.start()
         logger.debug("IP Secondary {} has been started with port {} and verification type {}".format(self.id, self.port, self.verification_type))
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._process.terminate()
         self._process.wait(timeout=60)
+        if not self._output_logs:
+            self._stdout_thread.join(10)
         logger.debug("IP Secondary {} has been stopped with port {} and verification type {}".format(self.id, self.port, self.verification_type))
+
+    def output(self):
+        if self._output_logs:
+            # stdout has gone to the console...
+            raise Exception("Can't get output from IP Secondary object if output_logs is set")
+        return self._stdout.getbuffer().tobytes().decode(errors='replace')
 
     def wait_for_completion(self, timeout=120):
         self._process.wait(timeout)


### PR DESCRIPTION
There wasn't anything reading the stdout of aktualizr when the output was set
to capture. As long as 'not much' output was written by aktualizr then it
didn't block and the test would get to the point where it can finish. There
doesn't seem to be an easy way to handle this in Python, so I wrote a quick
utility to copy the stdout to an in-memory buffer in a background thread.

Signed-off-by: Phil Wise <phil@phil-wise.com>