### PR TITLE
uptane-generator: Allow adding custom metadata for all images.

### DIFF
--- a/src/aktualizr_secondary/aktualizr_secondary_ostree_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_ostree_test.cc
@@ -160,11 +160,7 @@ class UptaneRepoWrapper {
 
   Uptane::SecondaryMetadata addOstreeRev(const std::string& rev, const std::string& hardware_id,
                                          const std::string& serial) {
-    // it makes sense to add 'addOstreeImage' to UptaneRepo interface/class uptane_repo.h
-    auto custom = Json::Value();
-    custom["targetFormat"] = "OSTREE";
-    uptane_repo_.addCustomImage(rev, Hash(Hash::Type::kSha256, rev), 0, hardware_id, "", 0, Delegation(), custom);
-
+    uptane_repo_.addCustomImage(rev, Hash(Hash::Type::kSha256, rev), 0, hardware_id);
     uptane_repo_.addTarget(rev, hardware_id, serial, "");
     uptane_repo_.signTargets();
 

--- a/src/aktualizr_secondary/aktualizr_secondary_ostree_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_ostree_test.cc
@@ -161,7 +161,7 @@ class UptaneRepoWrapper {
   Uptane::SecondaryMetadata addOstreeRev(const std::string& rev, const std::string& hardware_id,
                                          const std::string& serial) {
     uptane_repo_.addCustomImage(rev, Hash(Hash::Type::kSha256, rev), 0, hardware_id);
-    uptane_repo_.addTarget(rev, hardware_id, serial, "");
+    uptane_repo_.addTarget(rev, hardware_id, serial);
     uptane_repo_.signTargets();
 
     return Uptane::SecondaryMetadata(getCurrentMetadata());

--- a/src/aktualizr_secondary/aktualizr_secondary_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_test.cc
@@ -85,7 +85,7 @@ class UptaneRepoWrapper {
 
     uptane_repo_.addImage(image_file_path, targetname, hardware_id);
     if (add_and_sign_target) {
-      uptane_repo_.addTarget(targetname, hardware_id, serial, "");
+      uptane_repo_.addTarget(targetname, hardware_id, serial);
       uptane_repo_.signTargets();
     }
 

--- a/src/aktualizr_secondary/secondary_tcp_server.cc
+++ b/src/aktualizr_secondary/secondary_tcp_server.cc
@@ -160,7 +160,7 @@ bool SecondaryTcpServer::HandleOneConnection(int socket) {
       default: {
         // TODO: consider sending NOT_SUPPORTED/Unknown message and closing connection socket
         keep_running_current_session = false;
-        LOG_INFO << "Unknown message received from Primary!";
+        LOG_INFO << "Unsupported message received from Primary: " << request_msg->toStr();
       }
     }  // switch
 

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -460,8 +460,7 @@ data::InstallationResult IpUptaneSecondary::install_v2(const Uptane::Target& tar
 }
 
 data::InstallationResult IpUptaneSecondary::downloadOstreeRev(const Uptane::Target& target) {
-  LOG_INFO << "Instructing Secondary ( " << getSerial() << " ) to download OSTree commit ( " << target.sha256Hash()
-           << " )";
+  LOG_INFO << "Instructing Secondary " << getSerial() << " to download OSTree commit " << target.sha256Hash();
   const std::string tls_creds = secondary_provider_->getTreehubCredentials();
   Asn1Message::Ptr req(Asn1Message::Empty());
   req->present(static_cast<AKIpUptaneMes_PR>(AKIpUptaneMes_PR_downloadOstreeRevReq));

--- a/src/libaktualizr/primary/CMakeLists.txt
+++ b/src/libaktualizr/primary/CMakeLists.txt
@@ -34,8 +34,8 @@ if (BUILD_OSTREE)
     add_aktualizr_test(NAME aktualizr_fullostree
                        SOURCES aktualizr_fullostree_test.cc
                        PROJECT_WORKING_DIRECTORY
-                       ARGS $<TARGET_FILE:uptane-generator> ${PROJECT_BINARY_DIR}/ostree_repo
-                       LIBRARIES virtual_secondary)
+                       ARGS ${PROJECT_BINARY_DIR}/ostree_repo
+                       LIBRARIES uptane_generator_lib virtual_secondary)
     set_target_properties(t_aktualizr_fullostree PROPERTIES LINK_FLAGS -Wl,--export-dynamic)
     add_dependencies(t_aktualizr_fullostree uptane-generator make_ostree_sysroot)
 

--- a/src/libaktualizr/primary/aktualizr_lite_test.cc
+++ b/src/libaktualizr/primary/aktualizr_lite_test.cc
@@ -36,16 +36,12 @@ class TufRepoMock {
   const std::string& url() { return url_; }
 
   Uptane::Target add_target(const std::string& target_name, const std::string& hash, const std::string& hardware_id) {
-    Json::Value custom_json;
-    custom_json["targetFormat"] = "OSTREE";
-    repo_.addCustomImage(target_name, Hash(Hash::Type::kSha256, hash), 0, hardware_id, "", 0, Delegation(),
-                         custom_json);
+    repo_.addCustomImage(target_name, Hash(Hash::Type::kSha256, hash), 0, hardware_id);
 
     Json::Value target;
     target["length"] = 0;
     target["hashes"]["sha256"] = hash;
-    target["custom"] = custom_json;
-
+    target["custom"]["targetFormat"] = "OSTREE";
     return Uptane::Target(target_name, target);
   }
 

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -1592,7 +1592,7 @@ TEST(Aktualizr, TargetAutoremove) {
   repo.generateRepo(KeyType::kED25519);
   const std::string hwid = "primary_hw";
   repo.addImage(fake_meta_dir / "fake_meta/primary_firmware.txt", "primary_firmware.txt", hwid);
-  repo.addTarget("primary_firmware.txt", hwid, "CA:FE:A6:D2:84:9D", "");
+  repo.addTarget("primary_firmware.txt", hwid, "CA:FE:A6:D2:84:9D");
   repo.signTargets();
 
   Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
@@ -1621,7 +1621,7 @@ TEST(Aktualizr, TargetAutoremove) {
   // second install
   repo.emptyTargets();
   repo.addImage(fake_meta_dir / "fake_meta/dummy_firmware.txt", "dummy_firmware.txt", hwid);
-  repo.addTarget("dummy_firmware.txt", hwid, "CA:FE:A6:D2:84:9D", "");
+  repo.addTarget("dummy_firmware.txt", hwid, "CA:FE:A6:D2:84:9D");
   repo.signTargets();
 
   {
@@ -1641,7 +1641,7 @@ TEST(Aktualizr, TargetAutoremove) {
   // third install (first firmware again)
   repo.emptyTargets();
   repo.addImage(fake_meta_dir / "fake_meta/primary_firmware.txt", "primary_firmware.txt", hwid);
-  repo.addTarget("primary_firmware.txt", hwid, "CA:FE:A6:D2:84:9D", "");
+  repo.addTarget("primary_firmware.txt", hwid, "CA:FE:A6:D2:84:9D");
   repo.signTargets();
 
   {
@@ -1661,7 +1661,7 @@ TEST(Aktualizr, TargetAutoremove) {
   // fourth install (some new third firmware)
   repo.emptyTargets();
   repo.addImage(fake_meta_dir / "fake_meta/secondary_firmware.txt", "secondary_firmware.txt", hwid);
-  repo.addTarget("secondary_firmware.txt", hwid, "CA:FE:A6:D2:84:9D", "");
+  repo.addTarget("secondary_firmware.txt", hwid, "CA:FE:A6:D2:84:9D");
   repo.signTargets();
 
   {

--- a/src/libaktualizr/primary/metadata_fetch_test.cc
+++ b/src/libaktualizr/primary/metadata_fetch_test.cc
@@ -87,7 +87,7 @@ TEST(Aktualizr, MetadataFetch) {
   // should be fetched once.
   uptane_repo_.addImage("tests/test_data/firmware.txt", "firmware.txt", "primary_hw");
   uptane_repo_.addImage("tests/test_data/firmware_name.txt", "firmware_name.txt", "primary_hw");
-  uptane_repo_.addTarget("firmware.txt", "primary_hw", "CA:FE:A6:D2:84:9D", "");
+  uptane_repo_.addTarget("firmware.txt", "primary_hw", "CA:FE:A6:D2:84:9D");
   uptane_repo_.addDelegation(Uptane::Role("role-abc", true), Uptane::Role("targets", false), "abc/*", false,
                              KeyType::kED25519);
   uptane_repo_.signTargets();
@@ -106,7 +106,7 @@ TEST(Aktualizr, MetadataFetch) {
   // Update scheduled with pre-existing image: no need to refetch Image repo
   // Snapshot or Targets metadata.
   uptane_repo_.emptyTargets();
-  uptane_repo_.addTarget("firmware_name.txt", "primary_hw", "CA:FE:A6:D2:84:9D", "");
+  uptane_repo_.addTarget("firmware_name.txt", "primary_hw", "CA:FE:A6:D2:84:9D");
   uptane_repo_.signTargets();
 
   update_result = aktualizr.CheckUpdates().get();
@@ -123,7 +123,7 @@ TEST(Aktualizr, MetadataFetch) {
   // Delegation added to an existing delegation; update scheduled with
   // pre-existing image: Snapshot must be refetched, but Targets are unchanged.
   uptane_repo_.emptyTargets();
-  uptane_repo_.addTarget("firmware.txt", "primary_hw", "CA:FE:A6:D2:84:9D", "");
+  uptane_repo_.addTarget("firmware.txt", "primary_hw", "CA:FE:A6:D2:84:9D");
   uptane_repo_.addDelegation(Uptane::Role("role-def", true), Uptane::Role("role-abc", true), "def/*", false,
                              KeyType::kED25519);
   uptane_repo_.signTargets();

--- a/src/uptane_generator/director_repo.h
+++ b/src/uptane_generator/director_repo.h
@@ -8,7 +8,7 @@ class DirectorRepo : public Repo {
   DirectorRepo(boost::filesystem::path path, const std::string &expires, std::string correlation_id)
       : Repo(Uptane::RepositoryType::Director(), std::move(path), expires, std::move(correlation_id)) {}
   void addTarget(const std::string &target_name, const Json::Value &target, const std::string &hardware_id,
-                 const std::string &ecu_serial, const std::string &url, const std::string &expires = "");
+                 const std::string &ecu_serial, const std::string &url = "", const std::string &expires = "");
   void revokeTargets(const std::vector<std::string> &targets_to_remove);
   void signTargets();
   void emptyTargets();

--- a/src/uptane_generator/image_repo.cc
+++ b/src/uptane_generator/image_repo.cc
@@ -20,7 +20,7 @@ void ImageRepo::addImage(const std::string &name, Json::Value &target, const std
 
 void ImageRepo::addBinaryImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
                                const std::string &hardware_id, const std::string &url, const int32_t custom_version,
-                               const Delegation &delegation) {
+                               const Delegation &delegation, const Json::Value &custom) {
   boost::filesystem::path repo_dir(path_ / ImageRepo::dir);
   boost::filesystem::path targets_path = repo_dir / "targets";
 
@@ -35,7 +35,10 @@ void ImageRepo::addBinaryImage(const boost::filesystem::path &image_path, const 
   target["length"] = Json::UInt64(image.size());
   target["hashes"]["sha256"] = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(image)));
   target["hashes"]["sha512"] = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(image)));
-  target["custom"]["targetFormat"] = "BINARY";
+  target["custom"] = custom;
+  if (!target["custom"].isMember("targetFormat")) {
+    target["custom"]["targetFormat"] = "BINARY";
+  }
   if (!url.empty()) {
     target["custom"]["uri"] = url;
   }
@@ -56,6 +59,9 @@ void ImageRepo::addCustomImage(const std::string &name, const Hash &hash, const 
     target["hashes"]["sha512"] = hash.HashString();
   }
   target["custom"] = custom;
+  if (!target["custom"].isMember("targetFormat")) {
+    target["custom"]["targetFormat"] = "OSTREE";
+  }
   if (!url.empty()) {
     target["custom"]["uri"] = url;
   }

--- a/src/uptane_generator/image_repo.h
+++ b/src/uptane_generator/image_repo.h
@@ -9,7 +9,7 @@ class ImageRepo : public Repo {
       : Repo(Uptane::RepositoryType::Image(), std::move(path), expires, std::move(correlation_id)) {}
   void addBinaryImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
                       const std::string &hardware_id, const std::string &url = "", int32_t custom_version = 0,
-                      const Delegation &delegation = {});
+                      const Delegation &delegation = {}, const Json::Value &custom = {});
   void addCustomImage(const std::string &name, const Hash &hash, uint64_t length, const std::string &hardware_id,
                       const std::string &url = "", int32_t custom_version = 0, const Delegation &delegation = {},
                       const Json::Value &custom = {});

--- a/src/uptane_generator/main.cc
+++ b/src/uptane_generator/main.cc
@@ -137,9 +137,21 @@ int main(int argc, char **argv) {
         if (vm.count("customversion") != 0) {
           custom_version = vm["customversion"].as<int32_t>();
         }
+        Json::Value custom;
+        if (vm.count("targetcustom") > 0 && vm.count("targetformat") > 0) {
+          std::cerr << "--targetcustom and --targetformat cannot be used together";
+          exit(EXIT_FAILURE);
+        }
+        if (vm.count("targetcustom") > 0) {
+          std::ifstream custom_file(vm["targetcustom"].as<boost::filesystem::path>().c_str());
+          custom_file >> custom;
+        } else if (vm.count("targetformat") > 0) {
+          custom = Json::Value();
+          custom["targetFormat"] = vm["targetformat"].as<std::string>();
+        }
         if (vm.count("filename") > 0) {
-          repo.addImage(vm["filename"].as<boost::filesystem::path>(), targetname, hwid, url, custom_version,
-                        delegation);
+          repo.addImage(vm["filename"].as<boost::filesystem::path>(), targetname, hwid, url, custom_version, delegation,
+                        custom);
           std::cout << "Added a target " << targetname << " to the Image repo metadata" << std::endl;
         } else {
           if ((vm.count("targetsha256") == 0 && vm.count("targetsha512") == 0) || vm.count("targetlength") == 0) {
@@ -152,18 +164,6 @@ int main(int argc, char **argv) {
             hash = std_::make_unique<Hash>(Hash::Type::kSha256, vm["targetsha256"].as<std::string>());
           } else {
             hash = std_::make_unique<Hash>(Hash::Type::kSha512, vm["targetsha512"].as<std::string>());
-          }
-          Json::Value custom;
-          if (vm.count("targetcustom") > 0 && vm.count("targetformat") > 0) {
-            std::cerr << "--targetcustom and --targetformat cannot be used together";
-            exit(EXIT_FAILURE);
-          }
-          if (vm.count("targetcustom") > 0) {
-            std::ifstream custom_file(vm["targetcustom"].as<boost::filesystem::path>().c_str());
-            custom_file >> custom;
-          } else if (vm.count("targetformat") > 0) {
-            custom = Json::Value();
-            custom["targetFormat"] = vm["targetformat"].as<std::string>();
           }
           repo.addCustomImage(targetname.string(), *hash, vm["targetlength"].as<uint64_t>(), hwid, url, custom_version,
                               delegation, custom);

--- a/src/uptane_generator/repo_test.cc
+++ b/src/uptane_generator/repo_test.cc
@@ -146,7 +146,7 @@ TEST(uptane_generator, copy_image) {
   UptaneRepo repo(temp_dir.Path(), "", "");
   repo.generateRepo(key_type);
   repo.addImage(temp_dir.Path() / DirectorRepo::dir / "manifest", "manifest", "test-hw");
-  repo.addTarget("manifest", "test-hw", "test-serial", "");
+  repo.addTarget("manifest", "test-hw", "test-serial");
   repo.signTargets();
   Json::Value image_targets = Utils::parseJSONFile(temp_dir.Path() / ImageRepo::dir / "targets.json");
   EXPECT_EQ(image_targets["signed"]["targets"].size(), 1);
@@ -167,7 +167,7 @@ TEST(uptane_generator, image_custom_url) {
   UptaneRepo repo(temp_dir.Path(), "", "");
   repo.generateRepo(key_type);
   repo.addImage(temp_dir.Path() / DirectorRepo::dir / "manifest", "manifest", "test-hw", "test-url");
-  repo.addTarget("manifest", "test-hw", "test-serial", "");
+  repo.addTarget("manifest", "test-hw", "test-serial");
   repo.signTargets();
   Json::Value image_targets = Utils::parseJSONFile(temp_dir.Path() / ImageRepo::dir / "targets.json");
   EXPECT_EQ(image_targets["signed"]["targets"].size(), 1);
@@ -210,7 +210,7 @@ TEST(uptane_generator, image_custom_version) {
   UptaneRepo repo(temp_dir.Path(), "", "");
   repo.generateRepo(key_type);
   repo.addImage(temp_dir.Path() / DirectorRepo::dir / "manifest", "manifest", "test-hw", "", 42);
-  repo.addTarget("manifest", "test-hw", "test-serial", "");
+  repo.addTarget("manifest", "test-hw", "test-serial");
   repo.signTargets();
   Json::Value image_targets = Utils::parseJSONFile(temp_dir.Path() / ImageRepo::dir / "targets.json");
   EXPECT_EQ(image_targets["signed"]["targets"].size(), 1);
@@ -489,9 +489,9 @@ TEST(uptane_generator, oldtargets) {
   Hash hash(Hash::Type::kSha256, "8ab755c16de6ee9b6224169b36cbf0f2a545f859be385501ad82cdccc240d0a6");
   repo.addCustomImage("target1", hash, 123, "test-hw");
   repo.addCustomImage("target2", hash, 321, "test-hw");
-  repo.addTarget("target1", "test-hw", "test-serial", "");
+  repo.addTarget("target1", "test-hw", "test-serial");
   repo.signTargets();
-  repo.addTarget("target2", "test-hw", "test-serial", "");
+  repo.addTarget("target2", "test-hw", "test-serial");
 
   Json::Value targets = Utils::parseJSONFile(temp_dir.Path() / DirectorRepo::dir / "staging/targets.json");
   EXPECT_EQ(targets["targets"].size(), 2);

--- a/src/uptane_generator/uptane_repo.cc
+++ b/src/uptane_generator/uptane_repo.cc
@@ -31,8 +31,8 @@ void UptaneRepo::revokeDelegation(const Uptane::Role &name) {
 
 void UptaneRepo::addImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
                           const std::string &hardware_id, const std::string &url, const int32_t custom_version,
-                          const Delegation &delegation) {
-  image_repo_.addBinaryImage(image_path, targetname, hardware_id, url, custom_version, delegation);
+                          const Delegation &delegation, const Json::Value &custom) {
+  image_repo_.addBinaryImage(image_path, targetname, hardware_id, url, custom_version, delegation, custom);
 }
 void UptaneRepo::addCustomImage(const std::string &name, const Hash &hash, uint64_t length,
                                 const std::string &hardware_id, const std::string &url, const int32_t custom_version,

--- a/src/uptane_generator/uptane_repo.h
+++ b/src/uptane_generator/uptane_repo.h
@@ -12,7 +12,7 @@ class UptaneRepo {
                  const std::string &url, const std::string &expires = "");
   void addImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
                 const std::string &hardware_id, const std::string &url = "", int32_t custom_version = 0,
-                const Delegation &delegation = {});
+                const Delegation &delegation = {}, const Json::Value &custom = {});
   void addCustomImage(const std::string &name, const Hash &hash, uint64_t length, const std::string &hardware_id,
                       const std::string &url = "", int32_t custom_version = 0, const Delegation &delegation = {},
                       const Json::Value &custom = {});

--- a/src/uptane_generator/uptane_repo.h
+++ b/src/uptane_generator/uptane_repo.h
@@ -9,7 +9,7 @@ class UptaneRepo {
   UptaneRepo(const boost::filesystem::path &path, const std::string &expires, const std::string &correlation_id);
   void generateRepo(KeyType key_type = KeyType::kRSA2048);
   void addTarget(const std::string &target_name, const std::string &hardware_id, const std::string &ecu_serial,
-                 const std::string &url, const std::string &expires = "");
+                 const std::string &url = "", const std::string &expires = "");
   void addImage(const boost::filesystem::path &image_path, const boost::filesystem::path &targetname,
                 const std::string &hardware_id, const std::string &url = "", int32_t custom_version = 0,
                 const Delegation &delegation = {}, const Json::Value &custom = {});

--- a/src/virtual_secondary/virtual_secondary_test.cc
+++ b/src/virtual_secondary/virtual_secondary_test.cc
@@ -49,7 +49,7 @@ TEST(VirtualSecondary, RootRotation) {
   UptaneRepo uptane_repo{meta_dir.PathString(), "", ""};
   uptane_repo.generateRepo(KeyType::kED25519);
   uptane_repo.addImage("tests/test_data/firmware.txt", "firmware.txt", "secondary_hw");
-  uptane_repo.addTarget("firmware.txt", "secondary_hw", "secondary_ecu_serial", "");
+  uptane_repo.addTarget("firmware.txt", "secondary_hw", "secondary_ecu_serial");
   uptane_repo.signTargets();
 
   result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
@@ -63,7 +63,7 @@ TEST(VirtualSecondary, RootRotation) {
   uptane_repo.rotate(Uptane::RepositoryType::Director(), Uptane::Role::Root(), KeyType::kED25519);
   uptane_repo.emptyTargets();
   uptane_repo.addImage("tests/test_data/firmware_name.txt", "firmware_name.txt", "secondary_hw");
-  uptane_repo.addTarget("firmware_name.txt", "secondary_hw", "secondary_ecu_serial", "");
+  uptane_repo.addTarget("firmware_name.txt", "secondary_hw", "secondary_ecu_serial");
   uptane_repo.signTargets();
 
   update_result = aktualizr.CheckUpdates().get();
@@ -77,7 +77,7 @@ TEST(VirtualSecondary, RootRotation) {
   uptane_repo.rotate(Uptane::RepositoryType::Image(), Uptane::Role::Root(), KeyType::kED25519);
   uptane_repo.emptyTargets();
   uptane_repo.addImage("tests/test_data/firmware.txt", "firmware2.txt", "secondary_hw");
-  uptane_repo.addTarget("firmware2.txt", "secondary_hw", "secondary_ecu_serial", "");
+  uptane_repo.addTarget("firmware2.txt", "secondary_hw", "secondary_ecu_serial");
   uptane_repo.signTargets();
 
   update_result = aktualizr.CheckUpdates().get();
@@ -109,7 +109,7 @@ TEST(VirtualSecondary, RootRotationFailure) {
   UptaneRepo uptane_repo{meta_dir.PathString(), "", ""};
   uptane_repo.generateRepo(KeyType::kED25519);
   uptane_repo.addImage("tests/test_data/firmware.txt", "firmware.txt", "secondary_hw");
-  uptane_repo.addTarget("firmware.txt", "secondary_hw", "secondary_ecu_serial", "");
+  uptane_repo.addTarget("firmware.txt", "secondary_hw", "secondary_ecu_serial");
   uptane_repo.signTargets();
 
   result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
@@ -123,7 +123,7 @@ TEST(VirtualSecondary, RootRotationFailure) {
   uptane_repo.rotate(Uptane::RepositoryType::Director(), Uptane::Role::Root(), KeyType::kED25519);
   uptane_repo.emptyTargets();
   uptane_repo.addImage("tests/test_data/firmware_name.txt", "firmware_name.txt", "secondary_hw");
-  uptane_repo.addTarget("firmware_name.txt", "secondary_hw", "secondary_ecu_serial", "");
+  uptane_repo.addTarget("firmware_name.txt", "secondary_hw", "secondary_ecu_serial");
   uptane_repo.signTargets();
 
   // This causes putRoot to be skipped, which means when the latest (v3)

--- a/tests/metafake.h
+++ b/tests/metafake.h
@@ -36,12 +36,12 @@ class MetaFake {
     file_name = "primary_firmware.txt";
     hwid = "primary_hw";
     repo.addImage(work_dir / file_name, file_name, hwid);
-    repo.addTarget(file_name.string(), hwid, "CA:FE:A6:D2:84:9D", "");
+    repo.addTarget(file_name.string(), hwid, "CA:FE:A6:D2:84:9D");
 
     file_name = "secondary_firmware.txt";
     hwid = "secondary_hw";
     repo.addImage(work_dir / file_name, file_name, hwid);
-    repo.addTarget(file_name.string(), hwid, "secondary_ecu_serial", "");
+    repo.addTarget(file_name.string(), hwid, "secondary_ecu_serial");
 
     repo.signTargets();
     rename("_hasupdates");
@@ -64,12 +64,12 @@ class MetaFake {
     file_name = "secondary_firmware.txt";
     hwid = "sec_hw1";
     repo.addImage(work_dir / file_name, file_name, hwid);
-    repo.addTarget(file_name.string(), hwid, "sec_serial1", "");
+    repo.addTarget(file_name.string(), hwid, "sec_serial1");
 
     file_name = "secondary_firmware2.txt";
     hwid = "sec_hw2";
     repo.addImage(work_dir / file_name, file_name, hwid);
-    repo.addTarget(file_name.string(), hwid, "sec_serial2", "");
+    repo.addTarget(file_name.string(), hwid, "sec_serial2");
 
     repo.signTargets();
     rename("_multisec");

--- a/tests/test_customrepo_failure.py
+++ b/tests/test_customrepo_failure.py
@@ -47,8 +47,6 @@ def test_customrepo_update_after_image_download_failure(uptane_repo, custom_repo
     Note: should aktualizr support unlimited number of redirects
 """
 @with_uptane_backend(start_generic_server=True)
-# TODO: Limit a number of HTTP redirects within a single request processing
-# https://saeljira.it.here.com/browse/OTA-3729
 @with_customrepo(handlers=[
                             RedirectHandler(number_of_redirects=10, url='/primary-image.img')
                         ])

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -822,7 +822,6 @@ class UptaneTestRepo:
                                   '--targetname', target_name,
                                   '--targetsha256', rev_hash,
                                   '--targetlength', '0',
-                                  '--targetformat', 'OSTREE',
                                   '--hwid', id[0]]
         subprocess.run(image_creation_cmdline, check=True)
 

--- a/tests/test_treehub_failure.py
+++ b/tests/test_treehub_failure.py
@@ -28,8 +28,7 @@ logger = logging.getLogger(__file__)
                         # https://saeljira.it.here.com/browse/OTA-3737
                         #SlowRetrievalHandler(url='/objects/6b/1604b586fcbe052bbc0bd9e1c8040f62e085ca2e228f37df957ac939dff361.filez'),
 
-                        # TODO: Limit a number of HTTP redirects within a single request processing
-                        # https://saeljira.it.here.com/browse/OTA-3729
+                        # TODO: Limit a number of HTTP redirects with OSTree fetches (currently not possible)
                         #RedirectHandler(number_of_redirects=1000, url='/objects/41/5ce9717fc7a5f4d743a4f911e11bd3ed83930e46756303fd13a3eb7ed35892.filez')
 ])
 @with_sysroot()


### PR DESCRIPTION
Also, `url` is now an optional for `addImage()`, and I cleaned up some other minor things.

~~Currently based on https://github.com/uptane/aktualizr/pull/46, since I assume we'll merge that soon.~~