### PR TITLE
Support custom fetch URIs for OSTree targets

### DIFF
--- a/src/libaktualizr/package_manager/ostreemanager.cc
+++ b/src/libaktualizr/package_manager/ostreemanager.cc
@@ -108,9 +108,20 @@ data::InstallationResult OstreeManager::pull(const boost::filesystem::path &sysr
     error = nullptr;
   }
 
-  if (alt_remote == nullptr && !OstreeManager::addRemote(repo.get(), ostree_server, keys)) {
-    return data::InstallationResult(data::ResultCode::Numeric::kInstallFailed,
-                                    std::string("Error adding a default OSTree remote: ") + remote);
+  if (alt_remote == nullptr) {
+    std::string ostree_remote_uri;
+    // If the Target specifies a custom fetch uri, use that.
+    std::string uri_override = target.uri();
+    if (uri_override.empty()) {
+      ostree_remote_uri = ostree_server;
+    } else {
+      ostree_remote_uri = uri_override;
+    }
+    // addRemote overwrites any previous ostree remote that was set
+    if (!OstreeManager::addRemote(repo.get(), ostree_remote_uri, keys)) {
+      return data::InstallationResult(data::ResultCode::Numeric::kInstallFailed,
+                                      std::string("Error adding a default OSTree remote: ") + remote);
+    }
   }
 
   g_variant_builder_init(&builder, G_VARIANT_TYPE("a{sv}"));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -232,6 +232,11 @@ if(BUILD_OSTREE)
              COMMAND ${PROJECT_SOURCE_DIR}/tests/test_misc_ostree_update.py
              --build-dir ${PROJECT_BINARY_DIR} --src-dir ${PROJECT_SOURCE_DIR})
     set_tests_properties(test_misc_ostree_update PROPERTIES LABELS "noptest")
+
+    add_test(NAME test_ostree_custom_uri
+            COMMAND ${PROJECT_SOURCE_DIR}/tests/test_ostree_custom_uri.py
+            --build-dir ${PROJECT_BINARY_DIR} --src-dir ${PROJECT_SOURCE_DIR})
+    set_tests_properties(test_ostree_custom_uri PROPERTIES LABELS "noptest")
 endif(BUILD_OSTREE)
 
 add_test(NAME test_aktualizr_kill

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -813,7 +813,7 @@ class UptaneTestRepo:
 
         return target_hash
 
-    def add_ostree_target(self, id, rev_hash, target_name=None, expires_within_sec=(60 * 5)):
+    def add_ostree_target(self, id, rev_hash, target_name=None, expires_within_sec=(60 * 5), target_uri=None):
         # emulate the backend behavior on defining a target name for OSTREE target format
         target_name = rev_hash if target_name is None else "{}-{}".format(target_name, rev_hash)
         image_creation_cmdline = [self._repo_manager_exe,
@@ -823,6 +823,8 @@ class UptaneTestRepo:
                                   '--targetsha256', rev_hash,
                                   '--targetlength', '0',
                                   '--hwid', id[0]]
+        if target_uri is not None:
+            image_creation_cmdline += ["--url", target_uri]
         subprocess.run(image_creation_cmdline, check=True)
 
         expiration_time = time.time() + expires_within_sec

--- a/tests/test_ostree_custom_uri.py
+++ b/tests/test_ostree_custom_uri.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import logging
+import argparse
+from functools import wraps
+
+from os import getcwd, chdir
+
+from test_fixtures import KeyStore, with_aktualizr, with_uptane_backend, with_director, with_imagerepo, \
+    with_sysroot, TestRunner, Treehub
+
+
+logger = logging.getLogger(__file__)
+
+
+class CustomUriTreehub(Treehub):
+    prefix = '/mycustomuri'
+
+    def __init__(self, ifc, port, client_handler_map={}):
+        self.hits_with_prefix = 0
+        super(CustomUriTreehub, self).__init__(ifc=ifc, port=port, client_handler_map=client_handler_map)
+
+    class Handler(Treehub.Handler):
+        def default_get(self):
+            if self.path.startswith(CustomUriTreehub.prefix):
+                self.server.hits_with_prefix += 1
+                self.path = self.path[len(CustomUriTreehub.prefix):]
+
+            super(CustomUriTreehub.Handler, self).default_get()
+
+
+def with_custom_treehub_uri(handlers=[], port=0):
+    def decorator(test):
+        @wraps(test)
+        def wrapper(*args, **kwargs):
+            def func(handler_map={}):
+                with CustomUriTreehub('localhost', port=port, client_handler_map=handler_map) as treehub:
+                    return test(*args, **kwargs, treehub=treehub)
+
+            if handlers and len(handlers) > 0:
+                for handler in handlers:
+                    result = func(handler.map(kwargs.get('test_path', '')))
+                    if not result:
+                        break
+            else:
+                result = func()
+            return result
+        return wrapper
+    return decorator
+
+
+"""
+Test setting a custom URI in OSTree
+"""
+@with_uptane_backend(start_generic_server=True)
+@with_director()
+@with_custom_treehub_uri()
+@with_sysroot()
+@with_aktualizr(start=False, run_mode='once', output_logs=True)
+def test_ostree_custom_uri(uptane_repo, aktualizr, director, sysroot,
+                                               treehub, **kwargs):
+    target_rev = treehub.revision
+    # add an OSTree update with a custom URI
+    uptane_repo.add_ostree_target(aktualizr.id, target_rev, target_uri=treehub.base_url + '/mycustomuri')
+
+    with aktualizr:
+        aktualizr.wait_for_completion()
+
+    if treehub.hits_with_prefix <= 5:
+        logger.error("Didn't fetch from custom URI. Got %d hits with %s prefix",
+                     treehub.hits_with_prefix, CustomUriTreehub.prefix)
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser(description='Test backend failure')
+    parser.add_argument('-b', '--build-dir', help='build directory', default='build')
+    parser.add_argument('-s', '--src-dir', help='source directory', default='.')
+
+    input_params = parser.parse_args()
+
+    KeyStore.base_dir = input_params.src_dir
+    initial_cwd = getcwd()
+    chdir(input_params.build_dir)
+
+    test_suite = [
+        test_ostree_custom_uri,
+    ]
+
+    with TestRunner(test_suite) as runner:
+        test_suite_run_result = runner.run()
+
+    chdir(initial_cwd)
+    exit(0 if test_suite_run_result else 1)


### PR DESCRIPTION
Binary targets already support fetching from a custom URI (URL). Teach
OstreeManager to respect custom.uri too.

Signed-off-by: Phil Wise <phil@phil-wise.com>