### PR TITLE
Don't fail metadata check if IP Secondaries don't support Root version requests.

### DIFF
--- a/src/aktualizr_secondary/secondary_rpc_test.cc
+++ b/src/aktualizr_secondary/secondary_rpc_test.cc
@@ -804,8 +804,8 @@ TEST(SecondaryTcpServer, TestIpSecondaryIfSecondaryIsNotRunning) {
   Uptane::Target target = target_file.createTarget(package_manager);
 
   // Expect failures since the Secondary is not running.
-  EXPECT_EQ(ip_secondary->getRootVersion(true), -1);
-  EXPECT_EQ(ip_secondary->getRootVersion(false), -1);
+  EXPECT_EQ(ip_secondary->getRootVersion(true), 0);
+  EXPECT_EQ(ip_secondary->getRootVersion(false), 0);
   EXPECT_FALSE(ip_secondary->putRoot("director-root-v2", true).isSuccess());
   EXPECT_FALSE(ip_secondary->putRoot("image-root-v2", false).isSuccess());
   EXPECT_FALSE(ip_secondary->putMetadata(target).isSuccess());

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -283,10 +283,11 @@ int32_t IpUptaneSecondary::getRootVersion(bool director) const {
   auto resp = Asn1Rpc(req, getAddr());
   if (resp->present() != AKIpUptaneMes_PR_rootVerResp) {
     // v1 (and v2 until this was added) Secondaries won't understand this.
-    // Return -1 to indicate an invalid value. Sending intermediate Roots will
-    // be skipped, which will probably be fatal.
+    // Return 0 to indicate that this is unsupported. Sending intermediate Roots
+    // will be skipped, which could be fatal. There isn't a good way to
+    // distinguish this from real errors in the message protocol.
     LOG_ERROR << "Secondary " << getSerial() << " failed to respond to a Root version request.";
-    return -1;
+    return 0;
   }
   auto r = resp->rootVerResp();
   return static_cast<int32_t>(r->version);

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -1250,6 +1250,9 @@ data::InstallationResult SotaUptaneClient::rotateSecondaryRoot(Uptane::Repositor
   data::InstallationResult result{data::ResultCode::Numeric::kOk, ""};
   const int last_root_version = Uptane::extractVersionUntrusted(latest_root);
   const int sec_root_version = secondary.getRootVersion((repo == Uptane::RepositoryType::Director()));
+  // If sec_root_version is 0, assume either the Secondary doesn't have Root
+  // metadata or doesn't support the Root version request. Continue on and hope
+  // for the best.
   if (sec_root_version < 0) {
     LOG_WARNING << "Secondary with serial " << secondary.getSerial() << " reported an invalid " << repo
                 << " repo Root version: " << sec_root_version;


### PR DESCRIPTION
Older versions don't support it, so if you run a newer Primary expecting the support with an older Secondary that doesn't, the metadata will fail to get sent no matter what you do. (Well, you can remove the Secondary, but that's pretty nasty.) This change makes the check more tolerant. If there's a problem with verifying the Root metadata (especially if an intermediate Root was skipped), the verification will still fail, but now at a slightly later phase (which is where it would've failed before).
