### PR TITLE
RFC: ApiQueue refactor

### DIFF
--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -9,6 +9,7 @@
 #include "utilities/timer.h"
 
 using std::make_shared;
+using std::move;
 using std::shared_ptr;
 
 Aktualizr::Aktualizr(const Config &config)
@@ -16,12 +17,12 @@ Aktualizr::Aktualizr(const Config &config)
 
 Aktualizr::Aktualizr(Config config, std::shared_ptr<INvStorage> storage_in,
                      const std::shared_ptr<HttpInterface> &http_in)
-    : config_{std::move(config)}, sig_{new event::Channel()}, api_queue_(new api::CommandQueue()) {
+    : config_{move(config)}, sig_{new event::Channel()}, api_queue_{new api::CommandQueue()} {
   if (sodium_init() == -1) {  // Note that sodium_init doesn't require a matching 'sodium_deinit'
     throw std::runtime_error("Unable to initialize libsodium");
   }
 
-  storage_ = std::move(storage_in);
+  storage_ = move(storage_in);
   storage_->importData(config_.import);
 
   uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, http_in, sig_);
@@ -125,7 +126,7 @@ std::vector<SecondaryInfo> Aktualizr::GetSecondaries() const {
 
 std::future<result::CampaignCheck> Aktualizr::CampaignCheck() {
   std::function<result::CampaignCheck()> task([this] { return uptane_client_->campaignCheck(); });
-  return api_queue_->enqueue(task);
+  return api_queue_->enqueue(move(task));
 }
 
 std::future<void> Aktualizr::CampaignControl(const std::string &campaign_id, campaign::Cmd cmd) {
@@ -144,29 +145,29 @@ std::future<void> Aktualizr::CampaignControl(const std::string &campaign_id, cam
         break;
     }
   });
-  return api_queue_->enqueue(task);
+  return api_queue_->enqueue(move(task));
 }
 
-void Aktualizr::SetCustomHardwareInfo(Json::Value hwinfo) { uptane_client_->setCustomHardwareInfo(std::move(hwinfo)); }
+void Aktualizr::SetCustomHardwareInfo(Json::Value hwinfo) { uptane_client_->setCustomHardwareInfo(move(hwinfo)); }
 std::future<void> Aktualizr::SendDeviceData() {
   std::function<void()> task([this] { uptane_client_->sendDeviceData(); });
-  return api_queue_->enqueue(task);
+  return api_queue_->enqueue(move(task));
 }
 
 std::future<result::UpdateCheck> Aktualizr::CheckUpdates() {
   std::function<result::UpdateCheck()> task([this] { return uptane_client_->fetchMeta(); });
-  return api_queue_->enqueue(task);
+  return api_queue_->enqueue(move(task));
 }
 
 std::future<result::Download> Aktualizr::Download(const std::vector<Uptane::Target> &updates) {
   std::function<result::Download(const api::FlowControlToken *)> task(
       [this, updates](const api::FlowControlToken *token) { return uptane_client_->downloadImages(updates, token); });
-  return api_queue_->enqueue(task);
+  return api_queue_->enqueue(move(task));
 }
 
 std::future<result::Install> Aktualizr::Install(const std::vector<Uptane::Target> &updates) {
   std::function<result::Install()> task([this, updates] { return uptane_client_->uptaneInstall(updates); });
-  return api_queue_->enqueue(task);
+  return api_queue_->enqueue(move(task));
 }
 
 bool Aktualizr::SetInstallationRawReport(const std::string &custom_raw_report) {
@@ -175,7 +176,7 @@ bool Aktualizr::SetInstallationRawReport(const std::string &custom_raw_report) {
 
 std::future<bool> Aktualizr::SendManifest(const Json::Value &custom) {
   std::function<bool()> task([this, custom]() { return uptane_client_->putManifest(custom); });
-  return api_queue_->enqueue(task);
+  return api_queue_->enqueue(move(task));
 }
 
 result::Pause Aktualizr::Pause() {
@@ -219,7 +220,7 @@ Aktualizr::InstallationLog Aktualizr::GetInstallationLog() {
     std::vector<Uptane::Target> log;
     storage_->loadInstallationLog(serial.ToString(), &log, true);
 
-    ilog.emplace_back(Aktualizr::InstallationLogEntry{serial, std::move(log)});
+    ilog.emplace_back(Aktualizr::InstallationLogEntry{serial, move(log)});
   }
 
   return ilog;

--- a/src/libaktualizr/utilities/CMakeLists.txt
+++ b/src/libaktualizr/utilities/CMakeLists.txt
@@ -22,6 +22,7 @@ set_property(SOURCE aktualizr_version.cc PROPERTY COMPILE_DEFINITIONS AKTUALIZR_
 
 add_library(utilities OBJECT ${SOURCES})
 
+add_aktualizr_test(NAME api_queue SOURCES api_queue_test.cc)
 add_aktualizr_test(NAME dequeue_buffer SOURCES dequeue_buffer_test.cc)
 add_aktualizr_test(NAME timer SOURCES timer_test.cc)
 add_aktualizr_test(NAME types SOURCES types_test.cc)

--- a/src/libaktualizr/utilities/api_queue_test.cc
+++ b/src/libaktualizr/utilities/api_queue_test.cc
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include "utilities/apiqueue.h"
+
+using std::cout;
+using std::future;
+using std::future_status;
+
+class CheckLifetime {
+ public:
+  CheckLifetime() { cout << "ctor\n"; }
+  ~CheckLifetime() {
+    valid = 999;
+    cout << "dtor\n";
+  }
+  CheckLifetime(const CheckLifetime& other) {
+    (void)other;
+    cout << "copy-ctor\n";
+  }
+  CheckLifetime& operator=(const CheckLifetime&) = delete;
+  CheckLifetime& operator=(CheckLifetime&&) = delete;
+  CheckLifetime(CheckLifetime&&) = delete;
+
+  int valid{100};
+};
+
+TEST(ApiQueue, Simple) {
+  api::CommandQueue dut;
+  future<int> result;
+  {
+    CheckLifetime checkLifetime;
+    std::function<int()> task([checkLifetime] {
+      cout << "Running task..." << checkLifetime.valid << "\n";
+      return checkLifetime.valid;
+    });
+    result = dut.enqueue(std::move(task));
+    cout << "Leaving scope..";
+  }
+  EXPECT_EQ(result.wait_for(std::chrono::milliseconds(100)), future_status::timeout);
+
+  dut.run();
+  // Include a timeout to avoid a failing test handing forever
+  ASSERT_EQ(result.wait_for(std::chrono::seconds(10)), future_status::ready);
+  EXPECT_EQ(result.get(), 100);
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+#endif


### PR DESCRIPTION
As part of work on offline updates, I pulled the API apart and rewrote it in a more explicit style. It turns out that I could make the offline changes independently of this, so I've split this change out.

The first two commits are pretty standard, but the last one is potentially controversial. I'm interested in your opinion on the relative readability of the before/after versions. 