### PR TITLE
Fix for the pkcs11/crypto tests

### DIFF
--- a/docker/Dockerfile.ubuntu.bionic
+++ b/docker/Dockerfile.ubuntu.bionic
@@ -74,6 +74,6 @@ RUN ./configure CFLAGS='-Wno-error=missing-prototypes' --with-libarchive --disab
 RUN make VERBOSE=1 -j4
 RUN make install
 
-RUN useradd testuser
+RUN useradd -m testuser
 
 WORKDIR /

--- a/docker/Dockerfile.ubuntu.focal
+++ b/docker/Dockerfile.ubuntu.focal
@@ -72,6 +72,6 @@ RUN apt-get update && apt-get -y install --no-install-suggests --no-install-reco
 RUN ln -s clang-11 /usr/bin/clang && \
     ln -s clang++-11 /usr/bin/clang++
 
-RUN useradd testuser
+RUN useradd -m testuser
 
 WORKDIR /

--- a/scripts/run_docker_test.sh
+++ b/scripts/run_docker_test.sh
@@ -48,10 +48,15 @@ docker build -t "${IMG_TAG}" -f "$DOCKERFILE" .
 
 # Prevent DOCKER_OPTS[@]: unbound variable
 # From SO: https://stackoverflow.com/a/34361807/6096518
-OPTS_STR=${DOCKER_OPTS[*]+"${DOCKER_OPTS[*]}"}
+OPTS_STR="${DOCKER_OPTS[*]+"${DOCKER_OPTS[*]}"}"
 
 # run under current user, mounting current directory at the same location in the container
 #
 # note: we've switched back to running the tests as root on CI when we switched from Jenkins to Gitlab
 # it would be great to revert to the old way at some point
-docker run -u "$(id -u):$(id -g)" -v "$PWD:$PWD" -w "$PWD" --rm "$OPTS_STR" -it "${IMG_TAG}" "$@"
+
+if [[ -z "${OPTS_STR}" ]]; then
+    docker run -u "$(id -u):$(id -g)" -v "$PWD:$PWD" -w "$PWD" --rm -it "${IMG_TAG}" "$@"
+else
+    docker run -u "$(id -u):$(id -g)" -v "$PWD:$PWD" -w "$PWD" --rm "${OPTS_STR}" -it "${IMG_TAG}" "$@"
+fi

--- a/src/aktualizr_secondary/secondary_tcp_server.cc
+++ b/src/aktualizr_secondary/secondary_tcp_server.cc
@@ -107,7 +107,7 @@ bool SecondaryTcpServer::HandleOneConnection(int socket) {
   while (keep_running_current_session) {  // Keep reading until we get an error
     // Read an incoming message
     AKIpUptaneMes_t *m = nullptr;
-    asn_dec_rval_t res;
+    asn_dec_rval_t res{};
     asn_codec_ctx_s context{};
     ssize_t received;
 

--- a/src/libaktualizr/crypto/crypto_test.cc
+++ b/src/libaktualizr/crypto/crypto_test.cc
@@ -75,7 +75,7 @@ TEST(crypto, sign_verify_rsa_p11) {
 }
 
 /* Generate RSA keypairs via PKCS#11. */
-TEST(crypto, DISABLED_generate_rsa_keypair_p11) {
+TEST(crypto, generate_rsa_keypair_p11) {
   P11Config config;
   config.module = TEST_PKCS11_MODULE_PATH;
   config.pass = "1234";
@@ -89,7 +89,7 @@ TEST(crypto, DISABLED_generate_rsa_keypair_p11) {
 }
 
 /* Read a TLS certificate via PKCS#11. */
-TEST(crypto, DISABLED_certificate_pkcs11) {
+TEST(crypto, certificate_pkcs11) {
   P11Config p11_conf;
   p11_conf.module = TEST_PKCS11_MODULE_PATH;
   p11_conf.pass = "1234";

--- a/src/libaktualizr/crypto/crypto_test.cc
+++ b/src/libaktualizr/crypto/crypto_test.cc
@@ -50,6 +50,22 @@ TEST(crypto, sign_verify_rsa_file) {
 }
 
 #ifdef BUILD_P11
+
+class P11Crypto : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { p11_ = std::make_shared<P11EngineGuard>(module_path_, pass_); }
+
+  static void TearDownTestSuite() { p11_.reset(); }
+
+  static boost::filesystem::path module_path_;
+  static std::string pass_;
+  static std::shared_ptr<P11EngineGuard> p11_;
+};
+
+boost::filesystem::path P11Crypto::module_path_{TEST_PKCS11_MODULE_PATH};
+std::string P11Crypto::pass_{"1234"};
+std::shared_ptr<P11EngineGuard> P11Crypto::p11_{nullptr};
+
 TEST(crypto, findPkcsLibrary) {
   const boost::filesystem::path pkcs11Path = P11Engine::findPkcsLibrary();
   EXPECT_NE(pkcs11Path, "");
@@ -57,47 +73,35 @@ TEST(crypto, findPkcsLibrary) {
 }
 
 /* Sign and verify a file with RSA via PKCS#11. */
-TEST(crypto, sign_verify_rsa_p11) {
-  P11Config config;
-  config.module = TEST_PKCS11_MODULE_PATH;
-  config.pass = "1234";
-  config.uptane_key_id = "03";
+TEST_F(P11Crypto, sign_verify_rsa_p11) {
+  const std::string uptane_key_id{"03"};
 
-  P11EngineGuard p11(config);
   std::string text = "This is text for sign";
   std::string key_content;
-  EXPECT_TRUE(p11->readUptanePublicKey(&key_content));
+  EXPECT_TRUE((*p11_)->readUptanePublicKey(uptane_key_id, &key_content));
   PublicKey pkey(key_content, KeyType::kRSA2048);
-  std::string private_key = p11->getUptaneKeyId();
-  std::string signature = Utils::toBase64(Crypto::RSAPSSSign(p11->getEngine(), private_key, text));
+  std::string private_key = (*p11_)->getItemFullId(uptane_key_id);
+  std::string signature = Utils::toBase64(Crypto::RSAPSSSign((*p11_)->getEngine(), private_key, text));
   bool signe_is_ok = pkey.VerifySignature(signature, text);
   EXPECT_TRUE(signe_is_ok);
 }
 
 /* Generate RSA keypairs via PKCS#11. */
-TEST(crypto, generate_rsa_keypair_p11) {
-  P11Config config;
-  config.module = TEST_PKCS11_MODULE_PATH;
-  config.pass = "1234";
-  config.uptane_key_id = "05";
+TEST_F(P11Crypto, generate_rsa_keypair_p11) {
+  const std::string uptane_key_id{"05"};
 
-  P11EngineGuard p11(config);
   std::string key_content;
-  EXPECT_FALSE(p11->readUptanePublicKey(&key_content));
-  EXPECT_TRUE(p11->generateUptaneKeyPair());
-  EXPECT_TRUE(p11->readUptanePublicKey(&key_content));
+  EXPECT_FALSE((*p11_)->readUptanePublicKey(uptane_key_id, &key_content));
+  EXPECT_TRUE((*p11_)->generateUptaneKeyPair(uptane_key_id));
+  EXPECT_TRUE((*p11_)->readUptanePublicKey(uptane_key_id, &key_content));
 }
 
 /* Read a TLS certificate via PKCS#11. */
-TEST(crypto, certificate_pkcs11) {
-  P11Config p11_conf;
-  p11_conf.module = TEST_PKCS11_MODULE_PATH;
-  p11_conf.pass = "1234";
-  p11_conf.tls_clientcert_id = "01";
-  P11EngineGuard p11(p11_conf);
+TEST_F(P11Crypto, certificate_pkcs11) {
+  const std::string tls_clientcert_id{"01"};
 
   std::string cert;
-  bool res = p11->readTlsCert(&cert);
+  bool res = (*p11_)->readTlsCert(tls_clientcert_id, &cert);
   EXPECT_TRUE(res);
   if (!res) return;
 

--- a/src/libaktualizr/crypto/keymanager.cc
+++ b/src/libaktualizr/crypto/keymanager.cc
@@ -22,8 +22,8 @@ KeyManager::KeyManager(std::shared_ptr<INvStorage> backend, KeyManagerConfig con
                        const std::shared_ptr<P11EngineGuard> &p11)
     : backend_(std::move(backend)), config_(std::move(config)) {
   if (built_with_p11) {
-    if (!p11_) {
-      p11_ = std::make_shared<P11EngineGuard>(config_.p11);
+    if (!p11) {
+      p11_ = std::make_shared<P11EngineGuard>(config_.p11.module, config_.p11.pass);
     } else {
       p11_ = p11;
     }
@@ -82,7 +82,7 @@ std::string KeyManager::getPkeyFile() const {
     if (!built_with_p11) {
       throw std::runtime_error("Aktualizr was built without PKCS#11");
     }
-    pkey_file = (*p11_)->getTlsPkeyId();
+    pkey_file = (*p11_)->getItemFullId(config_.p11.tls_pkey_id);
   }
   if (config_.tls_pkey_source == CryptoSource::kFile) {
     if (tmp_pkey_file && !boost::filesystem::is_empty(tmp_pkey_file->PathString())) {
@@ -98,7 +98,7 @@ std::string KeyManager::getCertFile() const {
     if (!built_with_p11) {
       throw std::runtime_error("Aktualizr was built without PKCS#11");
     }
-    cert_file = (*p11_)->getTlsCertId();
+    cert_file = (*p11_)->getItemFullId(config_.p11.tls_clientcert_id);
   }
   if (config_.tls_cert_source == CryptoSource::kFile) {
     if (tmp_cert_file && !boost::filesystem::is_empty(tmp_cert_file->PathString())) {
@@ -114,7 +114,7 @@ std::string KeyManager::getCaFile() const {
     if (!built_with_p11) {
       throw std::runtime_error("Aktualizr was built without PKCS#11");
     }
-    ca_file = (*p11_)->getTlsCacertId();
+    ca_file = (*p11_)->getItemFullId(config_.p11.tls_cacert_id);
   }
   if (config_.tls_ca_source == CryptoSource::kFile) {
     if (tmp_ca_file && !boost::filesystem::is_empty(tmp_ca_file->PathString())) {
@@ -130,7 +130,7 @@ std::string KeyManager::getPkey() const {
     if (!built_with_p11) {
       throw std::runtime_error("Aktualizr was built without PKCS#11");
     }
-    pkey = (*p11_)->getTlsPkeyId();
+    pkey = (*p11_)->getItemFullId(config_.p11.tls_pkey_id);
   }
   if (config_.tls_pkey_source == CryptoSource::kFile) {
     backend_->loadTlsPkey(&pkey);
@@ -144,7 +144,7 @@ std::string KeyManager::getCert() const {
     if (!built_with_p11) {
       throw std::runtime_error("Aktualizr was built without PKCS#11");
     }
-    cert = (*p11_)->getTlsCertId();
+    cert = (*p11_)->getItemFullId(config_.p11.tls_clientcert_id);
   }
   if (config_.tls_cert_source == CryptoSource::kFile) {
     backend_->loadTlsCert(&cert);
@@ -158,7 +158,7 @@ std::string KeyManager::getCa() const {
     if (!built_with_p11) {
       throw std::runtime_error("Aktualizr was built without PKCS#11");
     }
-    ca = (*p11_)->getTlsCacertId();
+    ca = (*p11_)->getItemFullId(config_.p11.tls_cacert_id);
   }
   if (config_.tls_ca_source == CryptoSource::kFile) {
     backend_->loadTlsCa(&ca);
@@ -177,7 +177,7 @@ std::string KeyManager::getCN() const {
     if (!built_with_p11) {
       throw std::runtime_error("Aktualizr was built without PKCS#11 support, can't extract device_id");
     }
-    if (!(*p11_)->readTlsCert(&cert)) {
+    if (!(*p11_)->readTlsCert(config_.p11.tls_clientcert_id, &cert)) {
       throw std::runtime_error(not_found_cert_message);
     }
   }
@@ -197,7 +197,7 @@ void KeyManager::getCertInfo(std::string *subject, std::string *issuer, std::str
     if (!built_with_p11) {
       throw std::runtime_error("Aktualizr was built without PKCS#11 support, can't extract device certificate");
     }
-    if (!(*p11_)->readTlsCert(&cert)) {
+    if (!(*p11_)->readTlsCert(config_.p11.tls_clientcert_id, &cert)) {
       throw std::runtime_error(not_found_cert_message);
     }
   }
@@ -319,11 +319,11 @@ std::string KeyManager::generateUptaneKeyPair() {
       throw std::runtime_error("Aktualizr was built without PKCS#11 support!");
     }
     // dummy read to check if the key is present
-    if (!(*p11_)->readUptanePublicKey(&primary_public)) {
-      (*p11_)->generateUptaneKeyPair();
+    if (!(*p11_)->readUptanePublicKey(config_.p11.uptane_key_id, &primary_public)) {
+      (*p11_)->generateUptaneKeyPair(config_.p11.uptane_key_id);
     }
     // really read the key
-    if (primary_public.empty() && !(*p11_)->readUptanePublicKey(&primary_public)) {
+    if (primary_public.empty() && !(*p11_)->readUptanePublicKey(config_.p11.uptane_key_id, &primary_public)) {
       throw std::runtime_error("Could not get Uptane keys");
     }
   }
@@ -341,7 +341,7 @@ PublicKey KeyManager::UptanePublicKey() const {
       throw std::runtime_error("Aktualizr was built without PKCS#11 support!");
     }
     // dummy read to check if the key is present
-    if (!(*p11_)->readUptanePublicKey(&primary_public)) {
+    if (!(*p11_)->readUptanePublicKey(config_.p11.uptane_key_id, &primary_public)) {
       throw std::runtime_error("Could not get Uptane public key!");
     }
   }

--- a/src/libaktualizr/crypto/keymanager_test.cc
+++ b/src/libaktualizr/crypto/keymanager_test.cc
@@ -138,7 +138,7 @@ TEST(KeyManager, SignTufPkcs11) {
 }
 
 /* Generate Uptane keys, use them for signing, and verify them. */
-TEST(KeyManager, DISABLED_GenSignTufPkcs11) {
+TEST(KeyManager, GenSignTufPkcs11) {
   Json::Value tosign_json;
   tosign_json["mykey"] = "value";
 
@@ -165,7 +165,7 @@ TEST(KeyManager, DISABLED_GenSignTufPkcs11) {
 }
 
 /* Generate RSA keypairs via PKCS#11. */
-TEST(KeyManager, DISABLED_InitPkcs11Valid) {
+TEST(KeyManager, InitPkcs11Valid) {
   Config config;
   P11Config p11_conf;
   p11_conf.module = TEST_PKCS11_MODULE_PATH;

--- a/src/libaktualizr/crypto/keymanager_test.cc
+++ b/src/libaktualizr/crypto/keymanager_test.cc
@@ -111,15 +111,32 @@ TEST(KeyManager, InitFileValid) {
 }
 
 #ifdef BUILD_P11
+
+class P11KeyManager : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { p11_ = std::make_shared<P11EngineGuard>(module_path_, pass_); }
+
+  static void TearDownTestSuite() { p11_.reset(); }
+
+  static boost::filesystem::path module_path_;
+  static std::string pass_;
+  static std::shared_ptr<P11EngineGuard> p11_;
+};
+
+boost::filesystem::path P11KeyManager::module_path_{TEST_PKCS11_MODULE_PATH};
+std::string P11KeyManager::pass_{"1234"};
+std::shared_ptr<P11EngineGuard> P11KeyManager::p11_{nullptr};
+
 /* Sign and verify a file with RSA via PKCS#11. */
-TEST(KeyManager, SignTufPkcs11) {
+TEST_F(P11KeyManager, SignTufPkcs11) {
+  P11Config p11_conf;
+  p11_conf.module = module_path_;
+  p11_conf.pass = pass_;
+  p11_conf.uptane_key_id = "03";
+
   Json::Value tosign_json;
   tosign_json["mykey"] = "value";
 
-  P11Config p11_conf;
-  p11_conf.module = TEST_PKCS11_MODULE_PATH;
-  p11_conf.pass = "1234";
-  p11_conf.uptane_key_id = "03";
   Config config;
   config.p11 = p11_conf;
   config.uptane.key_source = CryptoSource::kPkcs11;
@@ -127,7 +144,7 @@ TEST(KeyManager, SignTufPkcs11) {
   TemporaryDirectory temp_dir;
   config.storage.path = temp_dir.Path();
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
-  KeyManager keys(storage, config.keymanagerConfig());
+  KeyManager keys(storage, config.keymanagerConfig(), p11_);
 
   EXPECT_GT(keys.UptanePublicKey().Value().size(), 0);
   Json::Value signed_json = keys.signTuf(tosign_json);
@@ -138,13 +155,13 @@ TEST(KeyManager, SignTufPkcs11) {
 }
 
 /* Generate Uptane keys, use them for signing, and verify them. */
-TEST(KeyManager, GenSignTufPkcs11) {
+TEST_F(P11KeyManager, GenSignTufPkcs11) {
   Json::Value tosign_json;
   tosign_json["mykey"] = "value";
 
   P11Config p11_conf;
-  p11_conf.module = TEST_PKCS11_MODULE_PATH;
-  p11_conf.pass = "1234";
+  p11_conf.module = module_path_;
+  p11_conf.pass = pass_;
   p11_conf.uptane_key_id = "06";
   Config config;
   config.p11 = p11_conf;
@@ -153,10 +170,10 @@ TEST(KeyManager, GenSignTufPkcs11) {
   TemporaryDirectory temp_dir;
   config.storage.path = temp_dir.Path();
   std::shared_ptr<INvStorage> storage = INvStorage::newStorage(config.storage);
-  KeyManager keys(storage, config.keymanagerConfig());
+  KeyManager keys(storage, config.keymanagerConfig(), p11_);
 
-  P11EngineGuard p11(config.p11);
-  EXPECT_TRUE(p11->generateUptaneKeyPair());
+  P11EngineGuard p11(config.p11.module, config.p11.pass);
+  EXPECT_TRUE(p11->generateUptaneKeyPair(p11_conf.uptane_key_id));
 
   EXPECT_GT(keys.UptanePublicKey().Value().size(), 0);
   Json::Value signed_json = keys.signTuf(tosign_json);
@@ -164,12 +181,12 @@ TEST(KeyManager, GenSignTufPkcs11) {
   EXPECT_NE(signed_json["signatures"][0]["sig"].asString().size(), 0);
 }
 
-/* Generate RSA keypairs via PKCS#11. */
-TEST(KeyManager, InitPkcs11Valid) {
+///* Generate RSA keypairs via PKCS#11. */
+TEST_F(P11KeyManager, InitPkcs11Valid) {
   Config config;
   P11Config p11_conf;
-  p11_conf.module = TEST_PKCS11_MODULE_PATH;
-  p11_conf.pass = "1234";
+  p11_conf.module = module_path_;
+  p11_conf.pass = pass_;
   p11_conf.tls_pkey_id = "02";
   p11_conf.tls_clientcert_id = "01";
   config.p11 = p11_conf;
@@ -183,7 +200,7 @@ TEST(KeyManager, InitPkcs11Valid) {
   // Getting the CA from the HSM is not currently supported.
   std::string ca = Utils::readFile("tests/test_data/prov/root.crt");
   storage->storeTlsCa(ca);
-  KeyManager keys(storage, config.keymanagerConfig());
+  KeyManager keys(storage, config.keymanagerConfig(), p11_);
   EXPECT_TRUE(keys.getCaFile().empty());
   EXPECT_FALSE(keys.getPkeyFile().empty());
   EXPECT_FALSE(keys.getCertFile().empty());

--- a/tests/aktualizr.supp
+++ b/tests/aktualizr.supp
@@ -52,6 +52,14 @@
     ...
 }
 {
+    libcrypto RSA_new_method
+    Memcheck:Leak
+    ...
+    fun:RSA_new_method
+    fun:_ZN6Crypto21generateRSAKeyPairEVPEi
+    ...
+}
+{
     libp11 RSA leak with Openssl 1.1 (https://github.com/OpenSC/libp11/pull/246)
     Memcheck:Leak
     ...


### PR DESCRIPTION
- Split the P11 engine config into two parts, the one that is really belongs to the engine, and the second that belongs to the key manager. The first part is static and is/should be the same across tests in a single test suite. The second part is modifiable, each test can specify its own values.
    
- Make the P11 engine singleton for a test suite. The openssl engine
cannot be loaded/initialized twice withing the same process, therefore each test cannot have its own instance of the P11 engine, it has to be a singleton within a system process.
