### PR TITLE
Speed up compiles with Include What You Use

### DIFF
--- a/include/libaktualizr/config.h
+++ b/include/libaktualizr/config.h
@@ -6,9 +6,9 @@
 #include <string>
 #include <vector>
 
-#include <boost/filesystem.hpp>
-#include <boost/program_options.hpp>
-#include <boost/property_tree/ini_parser.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/program_options/variables_map.hpp>
+#include <boost/property_tree/ptree_fwd.hpp>
 
 #include "libaktualizr/types.h"
 
@@ -193,13 +193,7 @@ class BaseConfig {
 
   void updateFromDirs(const std::vector<boost::filesystem::path>& configs);
 
-  static void checkDirs(const std::vector<boost::filesystem::path>& configs) {
-    for (const auto& config : configs) {
-      if (!boost::filesystem::exists(config)) {
-        throw std::runtime_error("Config directory " + config.string() + " does not exist.");
-      }
-    }
-  }
+  static void checkDirs(const std::vector<boost::filesystem::path>& configs);
 
   std::vector<boost::filesystem::path> config_dirs_ = {"/usr/lib/sota/conf.d", "/etc/sota/conf.d/"};
 };

--- a/include/libaktualizr/types.h
+++ b/include/libaktualizr/types.h
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <unordered_map>
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include "json/json.h"
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -124,6 +124,7 @@ if [[ $TEST_DRYRUN != 1 ]]; then
     fi
 
     set -x
+    git config --global --add safe.directory "${GITREPO_ROOT}"
     cmake "${CMAKE_ARGS[@]}" "${GITREPO_ROOT}" || add_fatal_failure "cmake configure"
     )
 fi

--- a/src/aktualizr_info/aktualizr_info_config.cc
+++ b/src/aktualizr_info/aktualizr_info_config.cc
@@ -1,5 +1,6 @@
 #include "aktualizr_info_config.h"
 
+#include "logging/logging.h"
 #include "utilities/config_utils.h"
 
 AktualizrInfoConfig::AktualizrInfoConfig(const boost::program_options::variables_map& cmd) {

--- a/src/aktualizr_info/aktualizr_info_config.h
+++ b/src/aktualizr_info/aktualizr_info_config.h
@@ -1,9 +1,10 @@
 #ifndef AKTUALIZR_INFO_CONFIG_H_
 #define AKTUALIZR_INFO_CONFIG_H_
 
-#include <boost/filesystem.hpp>
-#include <boost/program_options.hpp>
-#include <boost/property_tree/ini_parser.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/program_options/variables_map.hpp>
+#include <boost/property_tree/ptree_fwd.hpp>
+#include <iosfwd>
 
 #include "libaktualizr/config.h"
 #include "utilities/config_utils.h"

--- a/src/aktualizr_primary/secondary.cc
+++ b/src/aktualizr_primary/secondary.cc
@@ -3,6 +3,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/placeholders.hpp>
 #include <boost/bind/bind.hpp>
+#include <boost/filesystem.hpp>
 
 #include <algorithm>
 #include <unordered_map>

--- a/src/aktualizr_primary/secondary.h
+++ b/src/aktualizr_primary/secondary.h
@@ -1,7 +1,7 @@
 #ifndef SECONDARY_H_
 #define SECONDARY_H_
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include "libaktualizr/aktualizr.h"
 

--- a/src/aktualizr_primary/secondary_config.cc
+++ b/src/aktualizr_primary/secondary_config.cc
@@ -1,3 +1,4 @@
+#include <boost/filesystem.hpp>
 #include <fstream>
 #include <iostream>
 #include <unordered_map>

--- a/src/aktualizr_primary/secondary_config.h
+++ b/src/aktualizr_primary/secondary_config.h
@@ -5,7 +5,7 @@
 #include <unordered_map>
 
 #include <json/json.h>
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include "libaktualizr/types.h"
 #include "primary/secondary_config.h"

--- a/src/aktualizr_secondary/aktualizr_secondary_config.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.cc
@@ -2,6 +2,8 @@
 
 #include <sstream>
 
+#include "utilities/config_utils.h"
+
 template <>
 inline void CopyFromConfig(VerificationType& dest, const std::string& option_name,
                            const boost::property_tree::ptree& pt) {

--- a/src/aktualizr_secondary/aktualizr_secondary_config.h
+++ b/src/aktualizr_secondary/aktualizr_secondary_config.h
@@ -1,13 +1,15 @@
 #ifndef AKTUALIZR_SECONDARY_CONFIG_H_
 #define AKTUALIZR_SECONDARY_CONFIG_H_
 
-#include <boost/filesystem.hpp>
-#include <boost/program_options.hpp>
-#include <boost/property_tree/ini_parser.hpp>
+#include <netinet/in.h>                             // for in_port_t
+#include <boost/filesystem/path.hpp>                // for path
+#include <boost/program_options/variables_map.hpp>  // for variables_map
+#include <boost/property_tree/ptree_fwd.hpp>        // for ptree
+#include <iosfwd>                                   // for ostream
+#include <string>                                   // for string
 
-#include "libaktualizr/config.h"
-#include "libaktualizr/types.h"
-#include "utilities/config_utils.h"
+#include "libaktualizr/config.h"  // for BaseConfig, Bootl...
+#include "libaktualizr/types.h"   // for CryptoSource, Key...
 
 // Try to keep the order of config options the same as in
 // AktualizrSecondaryConfig::writeToStream() and

--- a/src/aktualizr_secondary/aktualizr_secondary_config_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_config_test.cc
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 
 #include "aktualizr_secondary_config.h"
+
+#include <fstream>
+
 #include "utilities/utils.h"
 
 TEST(aktualizr_secondary_config, config_initialized_values) {

--- a/src/aktualizr_secondary/aktualizr_secondary_test.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary_test.cc
@@ -1,14 +1,13 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <boost/process.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/optional/optional_io.hpp>
 
 #include "aktualizr_secondary_file.h"
 #include "crypto/keymanager.h"
 #include "libaktualizr/types.h"
 #include "storage/invstorage.h"
-#include "test_utils.h"
-#include "update_agent.h"
 #include "update_agent_file.h"
 #include "uptane_repo.h"
 #include "utilities/utils.h"

--- a/src/aktualizr_secondary/secondary_rpc_test.cc
+++ b/src/aktualizr_secondary/secondary_rpc_test.cc
@@ -2,11 +2,12 @@
 
 #include <gtest/gtest.h>
 #include <netinet/tcp.h>
+#include <boost/filesystem.hpp>
 
+#include "crypto/crypto.h"
+#include "ipuptanesecondary.h"
 #include "libaktualizr/packagemanagerfactory.h"
 #include "libaktualizr/packagemanagerinterface.h"
-
-#include "ipuptanesecondary.h"
 #include "logging/logging.h"
 #include "msg_handler.h"
 #include "primary/secondary_provider_builder.h"

--- a/src/aktualizr_secondary/update_agent_file.cc
+++ b/src/aktualizr_secondary/update_agent_file.cc
@@ -1,4 +1,7 @@
 #include "update_agent_file.h"
+
+#include <boost/filesystem.hpp>
+
 #include <fstream>
 #include "crypto/crypto.h"
 #include "logging/logging.h"

--- a/src/aktualizr_secondary/update_agent_ostree.cc
+++ b/src/aktualizr_secondary/update_agent_ostree.cc
@@ -1,5 +1,8 @@
 #include "update_agent_ostree.h"
 
+#include <boost/algorithm/string/trim.hpp>
+
+#include "logging/logging.h"
 #include "package_manager/ostreemanager.h"
 
 // TODO: consider moving this and SecondaryProvider::getTreehubCredentials to

--- a/src/cert_provider/cert_provider_shared_cred_test.cc
+++ b/src/cert_provider/cert_provider_shared_cred_test.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 
 #include "cert_provider_test.h"

--- a/src/cert_provider/cert_provider_test.cc
+++ b/src/cert_provider/cert_provider_test.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 
 #include "cert_provider_test.h"

--- a/src/libaktualizr-c/libaktualizr-c.cc
+++ b/src/libaktualizr-c/libaktualizr-c.cc
@@ -1,6 +1,7 @@
 #include "libaktualizr-c.h"
-#include "libaktualizr/events.h"
+#include <fstream>
 
+#include "libaktualizr/events.h"
 #include "utilities/utils.h"
 
 Aktualizr *Aktualizr_create_from_cfg(Config *cfg) {

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -4,10 +4,12 @@
 #include <netinet/tcp.h>
 
 #include <array>
+#include <fstream>
 #include <memory>
 
 #include "asn1/asn1_message.h"
 #include "der_encoder.h"
+#include "libaktualizr/secondary_provider.h"
 #include "logging/logging.h"
 #include "uptane/tuf.h"
 #include "utilities/utils.h"

--- a/src/libaktualizr/bootloader/bootloader.cc
+++ b/src/libaktualizr/bootloader/bootloader.cc
@@ -5,7 +5,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/operations.hpp>
 
 #include "storage/invstorage.h"
 #include "utilities/exceptions.h"

--- a/src/libaktualizr/bootloader/bootloader_test.cc
+++ b/src/libaktualizr/bootloader/bootloader_test.cc
@@ -1,7 +1,11 @@
 #include <gtest/gtest.h>
 
 #include "bootloader.h"
+
+#include <boost/filesystem.hpp>
+
 #include "storage/invstorage.h"
+#include "utilities/utils.h"
 
 /* Check that the reboot detection feature works */
 TEST(bootloader, detectReboot) {

--- a/src/libaktualizr/bootstrap/bootstrap.cc
+++ b/src/libaktualizr/bootstrap/bootstrap.cc
@@ -1,5 +1,6 @@
 #include "bootstrap.h"
 
+#include <fstream>
 #include <sstream>
 
 #include "crypto/crypto.h"

--- a/src/libaktualizr/bootstrap/bootstrap.h
+++ b/src/libaktualizr/bootstrap/bootstrap.h
@@ -1,7 +1,7 @@
 #ifndef AKTUALIZR_BOOTSTRAP_H
 #define AKTUALIZR_BOOTSTRAP_H
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 #include <string>
 
 class Bootstrap {

--- a/src/libaktualizr/campaign/campaign_test.cc
+++ b/src/libaktualizr/campaign/campaign_test.cc
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include "libaktualizr/campaign.h"
 

--- a/src/libaktualizr/config/base_config.cc
+++ b/src/libaktualizr/config/base_config.cc
@@ -1,8 +1,18 @@
 #include "libaktualizr/config.h"
 
+#include <boost/filesystem.hpp>
+
 #include "logging/logging.h"
 #include "utilities/config_utils.h"
 #include "utilities/utils.h"
+
+void BaseConfig::checkDirs(const std::vector<boost::filesystem::path>& configs) {
+  for (const auto& config : configs) {
+    if (!boost::filesystem::exists(config)) {
+      throw std::runtime_error("Config directory " + config.string() + " does not exist.");
+    }
+  }
+}
 
 void BaseConfig::updateFromToml(const boost::filesystem::path& filename) {
   LOG_INFO << "Reading config: " << filename;

--- a/src/libaktualizr/config/config.cc
+++ b/src/libaktualizr/config/config.cc
@@ -1,6 +1,5 @@
 #include <fcntl.h>
-#include <unistd.h>
-#include <iomanip>
+#include <boost/filesystem.hpp>
 #include <sstream>
 
 #include "bootstrap/bootstrap.h"

--- a/src/libaktualizr/crypto/crypto.cc
+++ b/src/libaktualizr/crypto/crypto.cc
@@ -3,9 +3,14 @@
 #include <array>
 #include <iostream>
 #include <random>
+#include <string>
 
+#include <openssl/pkcs12.h>
+#include <openssl/rsa.h>
 #include <sodium.h>
 #include <boost/algorithm/hex.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/scoped_array.hpp>
 
 #include "libaktualizr/types.h"
@@ -119,10 +124,18 @@ std::string Crypto::sha256digest(const std::string &text) {
   return std::string(reinterpret_cast<char *>(sha256_hash.data()), crypto_hash_sha256_BYTES);
 }
 
+std::string Crypto::sha256digestHex(const std::string &text) {
+  return boost::algorithm::to_lower_copy(boost::algorithm::hex(sha256digest(text)));
+}
+
 std::string Crypto::sha512digest(const std::string &text) {
   std::array<unsigned char, crypto_hash_sha512_BYTES> sha512_hash{};
   crypto_hash_sha512(sha512_hash.data(), reinterpret_cast<const unsigned char *>(text.c_str()), text.size());
   return std::string(reinterpret_cast<char *>(sha512_hash.data()), crypto_hash_sha512_BYTES);
+}
+
+std::string Crypto::sha512digestHex(const std::string &text) {
+  return boost::algorithm::to_lower_copy(boost::algorithm::hex(sha512digest(text)));
 }
 
 std::string Crypto::RSAPSSSign(ENGINE *engine, const std::string &private_key, const std::string &message) {
@@ -679,6 +692,18 @@ MultiPartHasher::Ptr MultiPartHasher::create(Hash::Type hash_type) {
       return nullptr;
     }
   }
+}
+
+std::string MultiPartSHA512Hasher::getHexDigest() {
+  std::array<unsigned char, crypto_hash_sha512_BYTES> sha512_hash{};
+  crypto_hash_sha512_final(&state_, sha512_hash.data());
+  return boost::algorithm::hex(std::string(reinterpret_cast<char *>(sha512_hash.data()), crypto_hash_sha512_BYTES));
+}
+
+std::string MultiPartSHA256Hasher::getHexDigest() {
+  std::array<unsigned char, crypto_hash_sha256_BYTES> sha256_hash{};
+  crypto_hash_sha256_final(&state_, sha256_hash.data());
+  return boost::algorithm::hex(std::string(reinterpret_cast<char *>(sha256_hash.data()), crypto_hash_sha256_BYTES));
 }
 
 Hash Hash::generate(Type type, const std::string &data) {

--- a/src/libaktualizr/crypto/keymanager.cc
+++ b/src/libaktualizr/crypto/keymanager.cc
@@ -3,10 +3,14 @@
 #include <stdexcept>
 #include <utility>
 
+#include <boost/filesystem.hpp>
 #include <boost/scoped_array.hpp>
 
+#include "crypto/crypto.h"
 #include "crypto/openssl_compat.h"
+#include "http/httpinterface.h"
 #include "libaktualizr/types.h"
+#include "p11engine.h"
 #include "storage/invstorage.h"
 
 // by using constexpr the compiler can optimize out method calls when the

--- a/src/libaktualizr/crypto/keymanager.h
+++ b/src/libaktualizr/crypto/keymanager.h
@@ -1,14 +1,18 @@
 #ifndef KEYMANAGER_H_
 #define KEYMANAGER_H_
 
-#include "libaktualizr/config.h"
+#include <memory>
+#include <string>
 
-#include "crypto.h"
-#include "http/httpinterface.h"
-#include "p11engine.h"
-#include "utilities/utils.h"
+#include "json/json.h"
 
+#include "libaktualizr/config.h"  // for KeyManagerConfig
+#include "libaktualizr/types.h"   // for KeyType, PublicKey
+#include "utilities/utils.h"      // for TemporaryFile
+
+class HttpInterface;
 class INvStorage;
+class P11EngineGuard;
 
 class KeyManager {
  public:

--- a/src/libaktualizr/crypto/keymanager_test.cc
+++ b/src/libaktualizr/crypto/keymanager_test.cc
@@ -1,9 +1,12 @@
 #include <gtest/gtest.h>
+
 #include <memory>
 
+#include <boost/filesystem.hpp>
 #include "json/json.h"
 
 #include "crypto/keymanager.h"
+#include "crypto/p11engine.h"
 #include "libaktualizr/config.h"
 #include "storage/sqlstorage.h"
 #include "utilities/utils.h"

--- a/src/libaktualizr/http/httpclient.cc
+++ b/src/libaktualizr/http/httpclient.cc
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <sstream>
 
-#include "utilities/aktualizr_version.h"
 #include "utilities/utils.h"
 
 struct WriteStringArg {

--- a/src/libaktualizr/http/httpclient.h
+++ b/src/libaktualizr/http/httpclient.h
@@ -9,8 +9,6 @@
 #include "json/json.h"
 
 #include "httpinterface.h"
-#include "logging/logging.h"
-#include "utilities/utils.h"
 
 /**
  * Helper class to manage curl_global_init/curl_global_cleanup calls

--- a/src/libaktualizr/logging/logging.cc
+++ b/src/libaktualizr/logging/logging.cc
@@ -1,4 +1,8 @@
 #include "logging.h"
+
+#include <boost/log/core/core.hpp>
+#include <boost/log/expressions.hpp>
+
 #include "libaktualizr/config.h"
 
 using boost::log::trivial::severity_level;

--- a/src/libaktualizr/logging/logging.h
+++ b/src/libaktualizr/logging/logging.h
@@ -1,9 +1,8 @@
 #ifndef SOTA_CLIENT_TOOLS_LOGGING_H_
 #define SOTA_CLIENT_TOOLS_LOGGING_H_
 
-#include <boost/log/core.hpp>
-#include <boost/log/expressions.hpp>
 #include <boost/log/trivial.hpp>
+#include <cstdint>
 
 struct LoggerConfig;
 

--- a/src/libaktualizr/package_manager/ostreemanager.h
+++ b/src/libaktualizr/package_manager/ostreemanager.h
@@ -1,6 +1,7 @@
 #ifndef OSTREE_H_
 #define OSTREE_H_
 
+#include <boost/optional/optional.hpp>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/libaktualizr/package_manager/packagemanagerconfig.cc
+++ b/src/libaktualizr/package_manager/packagemanagerconfig.cc
@@ -1,8 +1,3 @@
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/join.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/log/trivial.hpp>
-
 #include "libaktualizr/config.h"
 #include "utilities/config_utils.h"
 

--- a/src/libaktualizr/package_manager/packagemanagerfactory.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfactory.cc
@@ -1,7 +1,6 @@
-#include <cstdlib>
-#include <map>
-
 #include "libaktualizr/packagemanagerfactory.h"
+
+#include <map>
 
 #include "logging/logging.h"
 

--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -1,13 +1,15 @@
-#include <sys/statvfs.h>
-#include <chrono>
-
 #include "libaktualizr/packagemanagerinterface.h"
 
-#include "bootloader/bootloader.h"
+#include <sys/statvfs.h>
+#include <boost/filesystem.hpp>
+#include <chrono>
+
+#include "crypto/crypto.h"
 #include "crypto/keymanager.h"
 #include "http/httpclient.h"
 #include "logging/logging.h"
 #include "storage/invstorage.h"
+#include "uptane/exceptions.h"
 #include "uptane/fetcher.h"
 #include "utilities/apiqueue.h"
 

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <fstream>
 
 #include <sodium.h>
 

--- a/src/libaktualizr/primary/aktualizr_helpers.cc
+++ b/src/libaktualizr/primary/aktualizr_helpers.cc
@@ -1,6 +1,12 @@
-#include <set>
-
 #include "aktualizr_helpers.h"
+
+#include <algorithm>                 // for find_if
+#include <cstddef>                   // for size_t
+#include <string>                    // for operator==, string
+#include <vector>                    // for vector, vector<>::reference, _Bi...
+#include "libaktualizr/aktualizr.h"  // for Aktualizr, Aktualizr::Installati...
+#include "libaktualizr/events.h"     // for AllInstallsComplete, BaseEvent
+#include "libaktualizr/types.h"      // for Target
 
 void targets_autoclean_cb(Aktualizr &aktualizr, const std::shared_ptr<event::BaseEvent> &event) {
   if (!event->isTypeOf<event::AllInstallsComplete>()) {

--- a/src/libaktualizr/primary/aktualizr_helpers.h
+++ b/src/libaktualizr/primary/aktualizr_helpers.h
@@ -2,7 +2,11 @@
 #define AKTUALIZR_HELPERS_H_
 
 #include <memory>
-#include "libaktualizr/aktualizr.h"
+
+class Aktualizr;
+namespace event {
+class BaseEvent;
+}
 
 /*
  * Signal handler to remove old targets just after an installation completes

--- a/src/libaktualizr/primary/aktualizr_lite_test.cc
+++ b/src/libaktualizr/primary/aktualizr_lite_test.cc
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <future>
 #include <iostream>
 #include <string>
 #include <thread>
@@ -14,6 +13,7 @@
 #include "package_manager/ostreemanager.h"
 #include "storage/sqlstorage.h"
 #include "test_utils.h"
+#include "uptane/fetcher.h"
 #include "uptane/imagerepository.h"
 
 class TufRepoMock {

--- a/src/libaktualizr/primary/provisioner.cc
+++ b/src/libaktualizr/primary/provisioner.cc
@@ -6,6 +6,7 @@
 #include <boost/scoped_array.hpp>
 
 #include "bootstrap/bootstrap.h"
+#include "crypto/crypto.h"
 #include "crypto/keymanager.h"
 #include "logging/logging.h"
 

--- a/src/libaktualizr/primary/reportqueue.cc
+++ b/src/libaktualizr/primary/reportqueue.cc
@@ -2,6 +2,11 @@
 
 #include <chrono>
 
+#include "http/httpclient.h"
+#include "libaktualizr/config.h"
+#include "logging/logging.h"
+#include "storage/invstorage.h"
+
 ReportQueue::ReportQueue(const Config& config_in, std::shared_ptr<HttpInterface> http_client,
                          std::shared_ptr<INvStorage> storage_in)
     : config(config_in), http(std::move(http_client)), storage(std::move(storage_in)) {

--- a/src/libaktualizr/primary/reportqueue.h
+++ b/src/libaktualizr/primary/reportqueue.h
@@ -1,19 +1,20 @@
 #ifndef REPORTQUEUE_H_
 #define REPORTQUEUE_H_
 
+#include <json/json.h>
 #include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <queue>
 #include <thread>
+#include <utility>  // for move
 
-#include <json/json.h>
+#include "libaktualizr/types.h"  // for EcuSerial (ptr only), TimeStamp
+#include "utilities/utils.h"     // for Utils
 
-#include "http/httpclient.h"
-#include "libaktualizr/config.h"
-#include "logging/logging.h"
-#include "storage/invstorage.h"
-#include "uptane/tuf.h"
+class Config;
+class HttpInterface;
+class INvStorage;
 
 class ReportEvent {
  public:

--- a/src/libaktualizr/primary/secondary_provider.cc
+++ b/src/libaktualizr/primary/secondary_provider.cc
@@ -1,8 +1,11 @@
 #include "libaktualizr/secondary_provider.h"
 
+#include <fstream>
+
 #include "logging/logging.h"
 #include "storage/invstorage.h"
 #include "uptane/tuf.h"
+#include "utilities/utils.h"
 
 bool SecondaryProvider::getMetadata(Uptane::MetaBundle* meta_bundle, const Uptane::Target& target) const {
   if (!getDirectorMetadata(meta_bundle)) {

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -1,6 +1,7 @@
 #include "primary/sotauptaneclient.h"
 
 #include <fnmatch.h>
+#include <fstream>
 #include <memory>
 #include <utility>
 

--- a/src/libaktualizr/storage/fsstorage_read.cc
+++ b/src/libaktualizr/storage/fsstorage_read.cc
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <utility>
 
+#include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/scoped_array.hpp>
 #include "json/json.h"

--- a/src/libaktualizr/storage/fsstorage_read.h
+++ b/src/libaktualizr/storage/fsstorage_read.h
@@ -1,7 +1,7 @@
 #ifndef FSSTORAGE_READ_H_
 #define FSSTORAGE_READ_H_
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 #include "invstorage.h"
 
 class FSStorageRead {

--- a/src/libaktualizr/storage/invstorage.cc
+++ b/src/libaktualizr/storage/invstorage.cc
@@ -1,10 +1,13 @@
 #include "invstorage.h"
 
 #include <unistd.h>
+#include <boost/filesystem.hpp>
 
+#include "crypto/crypto.h"
 #include "fsstorage_read.h"
 #include "logging/logging.h"
 #include "sqlstorage.h"
+#include "uptane/exceptions.h"
 #include "utilities/utils.h"
 
 void INvStorage::importUpdateSimple(const boost::filesystem::path& base_path, store_data_t store_func,

--- a/src/libaktualizr/storage/invstorage.h
+++ b/src/libaktualizr/storage/invstorage.h
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/optional.hpp>
 
 #include "libaktualizr/config.h"

--- a/src/libaktualizr/storage/sql_utils.h
+++ b/src/libaktualizr/storage/sql_utils.h
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <string>
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/optional.hpp>
 
 #include <sqlite3.h>

--- a/src/libaktualizr/storage/sqlstorage.h
+++ b/src/libaktualizr/storage/sqlstorage.h
@@ -1,7 +1,6 @@
 #ifndef SQLSTORAGE_H_
 #define SQLSTORAGE_H_
 
-#include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
 
 #include <sqlite3.h>

--- a/src/libaktualizr/storage/sqlstorage_base.cc
+++ b/src/libaktualizr/storage/sqlstorage_base.cc
@@ -2,6 +2,8 @@
 #include "storage_exception.h"
 
 #include <sys/stat.h>
+#include <boost/filesystem.hpp>
+#include <fstream>
 
 #include "utilities/utils.h"
 

--- a/src/libaktualizr/storage/sqlstorage_base.h
+++ b/src/libaktualizr/storage/sqlstorage_base.h
@@ -1,7 +1,7 @@
 #ifndef SQLSTORAGE_BASE_H_
 #define SQLSTORAGE_BASE_H_
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/interprocess/sync/scoped_lock.hpp>
 

--- a/src/libaktualizr/storage/sqlstorage_test.cc
+++ b/src/libaktualizr/storage/sqlstorage_test.cc
@@ -1,6 +1,7 @@
-#include <boost/tokenizer.hpp>
-
 #include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/tokenizer.hpp>
 
 #include "logging/logging.h"
 #include "storage/sql_utils.h"

--- a/src/libaktualizr/storage/storage_common_test.cc
+++ b/src/libaktualizr/storage/storage_common_test.cc
@@ -5,6 +5,7 @@
 
 #include <boost/filesystem.hpp>
 
+#include "crypto/crypto.h"
 #include "libaktualizr/types.h"
 #include "repo.h"
 #include "storage/sqlstorage.h"

--- a/src/libaktualizr/uptane/director_test.cc
+++ b/src/libaktualizr/uptane/director_test.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "directorrepository.h"
+#include "logging/logging.h"
 #include "test_utils.h"
 #include "utilities/utils.h"
 

--- a/src/libaktualizr/uptane/directorrepository.cc
+++ b/src/libaktualizr/uptane/directorrepository.cc
@@ -1,6 +1,10 @@
 #include "directorrepository.h"
 
+#include "fetcher.h"
+#include "logging/logging.h"
 #include "storage/invstorage.h"
+#include "uptane/exceptions.h"
+#include "utilities/utils.h"
 
 namespace Uptane {
 

--- a/src/libaktualizr/uptane/imagerepository.cc
+++ b/src/libaktualizr/uptane/imagerepository.cc
@@ -1,6 +1,10 @@
 #include "imagerepository.h"
 
+#include "crypto/crypto.h"
+#include "fetcher.h"
+#include "logging/logging.h"
 #include "storage/invstorage.h"
+#include "uptane/exceptions.h"
 
 namespace Uptane {
 
@@ -55,7 +59,7 @@ void ImageRepository::verifySnapshot(const std::string& snapshot_raw, bool prefe
   for (const auto& it : timestamp.snapshot_hashes()) {
     switch (it.type()) {
       case Hash::Type::kSha256:
-        if (Hash(Hash::Type::kSha256, boost::algorithm::hex(Crypto::sha256digest(canonical))) != it) {
+        if (Hash(Hash::Type::kSha256, Crypto::sha256digestHex(canonical)) != it) {
           if (!prefetch) {
             LOG_ERROR << "Hash verification for Snapshot metadata failed";
           }
@@ -64,7 +68,7 @@ void ImageRepository::verifySnapshot(const std::string& snapshot_raw, bool prefe
         hash_exists = true;
         break;
       case Hash::Type::kSha512:
-        if (Hash(Hash::Type::kSha512, boost::algorithm::hex(Crypto::sha512digest(canonical))) != it) {
+        if (Hash(Hash::Type::kSha512, Crypto::sha512digestHex(canonical)) != it) {
           if (!prefetch) {
             LOG_ERROR << "Hash verification for Snapshot metadata failed";
           }
@@ -130,7 +134,7 @@ void ImageRepository::verifyRoleHashes(const std::string& role_data, const Uptan
   for (const auto& it : snapshot.role_hashes(role)) {
     switch (it.type()) {
       case Hash::Type::kSha256:
-        if (Hash(Hash::Type::kSha256, boost::algorithm::hex(Crypto::sha256digest(canonical))) != it) {
+        if (Hash(Hash::Type::kSha256, Crypto::sha256digestHex(canonical)) != it) {
           if (!prefetch) {
             LOG_ERROR << "Hash verification for " << role << " metadata failed";
           }
@@ -138,7 +142,7 @@ void ImageRepository::verifyRoleHashes(const std::string& role_data, const Uptan
         }
         break;
       case Hash::Type::kSha512:
-        if (Hash(Hash::Type::kSha512, boost::algorithm::hex(Crypto::sha512digest(canonical))) != it) {
+        if (Hash(Hash::Type::kSha512, Crypto::sha512digestHex(canonical)) != it) {
           if (!prefetch) {
             LOG_ERROR << "Hash verification for " << role << " metadata failed";
           }

--- a/src/libaktualizr/uptane/imagerepository.h
+++ b/src/libaktualizr/uptane/imagerepository.h
@@ -1,8 +1,8 @@
 #ifndef IMAGE_REPOSITORY_H_
 #define IMAGE_REPOSITORY_H_
 
-#include <map>
-#include <vector>
+#include <memory>
+#include <string>
 
 #include "uptanerepository.h"
 

--- a/src/libaktualizr/uptane/iterator.cc
+++ b/src/libaktualizr/uptane/iterator.cc
@@ -1,6 +1,7 @@
 #include "iterator.h"
 
 #include "storage/invstorage.h"
+#include "uptane/exceptions.h"
 
 namespace Uptane {
 

--- a/src/libaktualizr/uptane/manifest.cc
+++ b/src/libaktualizr/uptane/manifest.cc
@@ -1,6 +1,9 @@
 #include "manifest.h"
 
+#include <boost/algorithm/string/case_conv.hpp>
+
 #include "crypto/keymanager.h"
+#include "logging/logging.h"
 
 namespace Uptane {
 

--- a/src/libaktualizr/uptane/metawithkeys.cc
+++ b/src/libaktualizr/uptane/metawithkeys.cc
@@ -1,6 +1,10 @@
+#include "uptane/tuf.h"
+
+#include <boost/algorithm/string/case_conv.hpp>
+
 #include "logging/logging.h"
 #include "uptane/exceptions.h"
-#include "uptane/tuf.h"
+#include "utilities/utils.h"
 
 using Uptane::MetaWithKeys;
 

--- a/src/libaktualizr/uptane/role.cc
+++ b/src/libaktualizr/uptane/role.cc
@@ -2,6 +2,8 @@
 
 #include <sstream>
 
+#include "uptane/exceptions.h"
+
 using Uptane::Role;
 using Uptane::Version;
 

--- a/src/libaktualizr/uptane/tuf.cc
+++ b/src/libaktualizr/uptane/tuf.cc
@@ -4,14 +4,13 @@
 #include <ostream>
 #include <sstream>
 
-#include <boost/algorithm/hex.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <utility>
 
 #include "crypto/crypto.h"
 #include "libaktualizr/types.h"
 #include "logging/logging.h"
-#include "utilities/exceptions.h"
+#include "uptane/exceptions.h"
 
 using Uptane::Target;
 using Uptane::Version;
@@ -140,7 +139,7 @@ Target::Target(std::string filename, EcuMap ecus, std::vector<Hash> hashes, uint
 
 Target Target::Unknown() {
   Json::Value t_json;
-  t_json["hashes"]["sha256"] = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest("")));
+  t_json["hashes"]["sha256"] = Crypto::sha256digestHex("");
   t_json["length"] = 0;
   Uptane::Target target{"unknown", t_json};
 

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -9,12 +9,9 @@
 #include <map>
 #include <ostream>
 #include <set>
-#include <unordered_map>
 #include <vector>
 
-#include "crypto/crypto.h"
 #include "libaktualizr/types.h"
-#include "uptane/exceptions.h"
 
 namespace Uptane {
 

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -863,8 +863,8 @@ class HttpFakeProv : public HttpFake {
         file_primary = "unknown";
         file_secondary = "noimage";
         // Check for default initial value of packagemanagerfake.
-        hash_primary = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest("")));
-        hash_secondary = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest("")));
+        hash_primary = Crypto::sha256digestHex("");
+        hash_secondary = Crypto::sha256digestHex("");
       } else {
         file_primary = "primary_firmware.txt";
         file_secondary = "secondary_firmware.txt";

--- a/src/libaktualizr/uptane/uptanerepository.cc
+++ b/src/libaktualizr/uptane/uptanerepository.cc
@@ -1,20 +1,11 @@
 #include "uptane/uptanerepository.h"
 
-#include <cstdio>
-#include <utility>
-
-#include <openssl/bio.h>
-#include <openssl/pem.h>
-#include <openssl/x509.h>
-#include <boost/algorithm/hex.hpp>
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/trim.hpp>
 
-#include "bootstrap/bootstrap.h"
-#include "crypto/crypto.h"
-#include "crypto/openssl_compat.h"
+#include "fetcher.h"
 #include "logging/logging.h"
 #include "storage/invstorage.h"
+#include "uptane/exceptions.h"
 #include "utilities/utils.h"
 
 namespace Uptane {

--- a/src/libaktualizr/uptane/uptanerepository.h
+++ b/src/libaktualizr/uptane/uptanerepository.h
@@ -1,11 +1,15 @@
 #ifndef UPTANE_REPOSITORY_H_
 #define UPTANE_REPOSITORY_H_
 
-#include "fetcher.h"
+#include <cstdint>               // for int64_t
+#include <string>                // for string
+#include "libaktualizr/types.h"  // for TimeStamp
+#include "uptane/tuf.h"          // for Root, RepositoryType
 
 class INvStorage;
 
 namespace Uptane {
+class IMetadataFetcher;
 
 class RepositoryCommon {
  public:

--- a/src/libaktualizr/utilities/utils.h
+++ b/src/libaktualizr/utilities/utils.h
@@ -1,7 +1,7 @@
 #ifndef UTILS_H_
 #define UTILS_H_
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 #include <memory>
 #include <string>
 

--- a/src/libaktualizr/utilities/utils_test.cc
+++ b/src/libaktualizr/utilities/utils_test.cc
@@ -12,6 +12,7 @@
 
 #include <boost/algorithm/hex.hpp>
 #include <boost/archive/iterators/dataflow_exception.hpp>
+#include <boost/filesystem.hpp>
 
 #include "libaktualizr/types.h"
 #include "utilities/utils.h"

--- a/src/sota_tools/ostree_dir_repo.cc
+++ b/src/sota_tools/ostree_dir_repo.cc
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include <boost/filesystem.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 
 #include "logging/logging.h"

--- a/src/sota_tools/ostree_dir_repo.h
+++ b/src/sota_tools/ostree_dir_repo.h
@@ -1,7 +1,7 @@
 #ifndef SOTA_CLIENT_TOOLS_OSTREE_DIR_REPO_H_
 #define SOTA_CLIENT_TOOLS_OSTREE_DIR_REPO_H_
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include "ostree_ref.h"
 #include "ostree_repo.h"

--- a/src/sota_tools/ostree_http_repo.cc
+++ b/src/sota_tools/ostree_http_repo.cc
@@ -1,9 +1,9 @@
 #include "ostree_http_repo.h"
 
 #include <fcntl.h>
-
 #include <string>
 
+#include <boost/filesystem.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 
 namespace pt = boost::property_tree;

--- a/src/sota_tools/ostree_http_repo.h
+++ b/src/sota_tools/ostree_http_repo.h
@@ -1,7 +1,7 @@
 #ifndef SOTA_CLIENT_TOOLS_OSTREE_HTTP_REPO_H_
 #define SOTA_CLIENT_TOOLS_OSTREE_HTTP_REPO_H_
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include "logging/logging.h"
 #include "ostree_ref.h"

--- a/src/sota_tools/ostree_object.cc
+++ b/src/sota_tools/ostree_object.cc
@@ -3,6 +3,7 @@
 #include <glib.h>
 #include <ostree.h>
 #include <sys/stat.h>
+#include <boost/filesystem.hpp>
 #include <cassert>
 #include <cstring>
 #include <iostream>

--- a/src/sota_tools/ostree_object.h
+++ b/src/sota_tools/ostree_object.h
@@ -6,7 +6,7 @@
 #include <sstream>
 
 #include <curl/curl.h>
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include "gtest/gtest_prod.h"
 

--- a/src/sota_tools/ostree_ref.cc
+++ b/src/sota_tools/ostree_ref.cc
@@ -1,8 +1,7 @@
 #include "ostree_ref.h"
 
 #include <algorithm>
-#include <fstream>
-#include <iomanip>
+#include <boost/filesystem.hpp>
 #include <iostream>
 #include <iterator>
 #include <utility>

--- a/src/sota_tools/ostree_ref.h
+++ b/src/sota_tools/ostree_ref.h
@@ -4,7 +4,6 @@
 #include <sstream>
 
 #include <curl/curl.h>
-#include <boost/filesystem.hpp>
 
 #include "ostree_hash.h"
 #include "ostree_repo.h"

--- a/src/sota_tools/ostree_repo.h
+++ b/src/sota_tools/ostree_repo.h
@@ -4,7 +4,7 @@
 #include <map>
 #include <string>
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include "garage_common.h"
 #include "ostree_hash.h"

--- a/src/sota_tools/server_credentials.h
+++ b/src/sota_tools/server_credentials.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 
 enum class AuthMethod { kNone = 0, kBasic, kOauth2, kTls };
 

--- a/src/uptane_generator/director_repo.cc
+++ b/src/uptane_generator/director_repo.cc
@@ -1,5 +1,9 @@
 #include "director_repo.h"
 
+#include <boost/filesystem.hpp>
+
+#include "utilities/utils.h"
+
 void DirectorRepo::addTarget(const std::string &target_name, const Json::Value &target, const std::string &hardware_id,
                              const std::string &ecu_serial, const std::string &url, const std::string &expires) {
   const boost::filesystem::path current = path_ / DirectorRepo::dir / "targets.json";

--- a/src/uptane_generator/image_repo.cc
+++ b/src/uptane_generator/image_repo.cc
@@ -1,5 +1,10 @@
 #include "image_repo.h"
 
+#include <boost/filesystem.hpp>
+
+#include "crypto/crypto.h"
+#include "utilities/utils.h"
+
 void ImageRepo::addImage(const std::string &name, Json::Value &target, const std::string &hardware_id,
                          const Delegation &delegation) {
   boost::filesystem::path repo_dir(path_ / ImageRepo::dir);
@@ -33,8 +38,8 @@ void ImageRepo::addBinaryImage(const boost::filesystem::path &image_path, const 
 
   Json::Value target;
   target["length"] = Json::UInt64(image.size());
-  target["hashes"]["sha256"] = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(image)));
-  target["hashes"]["sha512"] = boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(image)));
+  target["hashes"]["sha256"] = Crypto::sha256digestHex(image);
+  target["hashes"]["sha512"] = Crypto::sha512digestHex(image);
   target["custom"] = custom;
   if (!target["custom"].isMember("targetFormat")) {
     target["custom"]["targetFormat"] = "BINARY";

--- a/src/uptane_generator/main.cc
+++ b/src/uptane_generator/main.cc
@@ -9,6 +9,7 @@
 #include "logging/logging.h"
 #include "uptane_repo.h"
 #include "utilities/aktualizr_version.h"
+#include "utilities/utils.h"
 
 namespace po = boost::program_options;
 

--- a/src/uptane_generator/repo.cc
+++ b/src/uptane_generator/repo.cc
@@ -1,6 +1,7 @@
 #include "repo.h"
 
 #include <array>
+#include <boost/filesystem.hpp>
 #include <ctime>
 #include <regex>
 
@@ -8,7 +9,6 @@
 #include "director_repo.h"
 #include "image_repo.h"
 #include "libaktualizr/campaign.h"
-#include "logging/logging.h"
 
 Repo::Repo(Uptane::RepositoryType repo_type, boost::filesystem::path path, const std::string &expires,
            std::string correlation_id)
@@ -36,8 +36,7 @@ void Repo::addDelegationToSnapshot(Json::Value *snapshot, const Uptane::Role &ro
 
   (*snapshot)["meta"][role_file_name]["version"] = role_json["version"].asUInt();
   (*snapshot)["meta"][role_file_name]["length"] = signed_role.size();
-  (*snapshot)["meta"][role_file_name]["hashes"]["sha256"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(signed_role)));
+  (*snapshot)["meta"][role_file_name]["hashes"]["sha256"] = Crypto::sha256digestHex(signed_role);
 
   if (role_json["delegations"].isObject()) {
     auto delegations_list = role_json["delegations"]["roles"];
@@ -65,10 +64,8 @@ void Repo::updateRepo() {
 
   Json::Value timestamp = Utils::parseJSONFile(repo_dir_ / "timestamp.json")["signed"];
   timestamp["version"] = (timestamp["version"].asUInt()) + 1;
-  timestamp["meta"]["snapshot.json"]["hashes"]["sha256"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(signed_snapshot)));
-  timestamp["meta"]["snapshot.json"]["hashes"]["sha512"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(signed_snapshot)));
+  timestamp["meta"]["snapshot.json"]["hashes"]["sha256"] = Crypto::sha256digestHex(signed_snapshot);
+  timestamp["meta"]["snapshot.json"]["hashes"]["sha512"] = Crypto::sha512digestHex(signed_snapshot);
   timestamp["meta"]["snapshot.json"]["length"] = static_cast<Json::UInt>(signed_snapshot.length());
   timestamp["meta"]["snapshot.json"]["version"] = snapshot["version"].asUInt();
   Utils::writeFile(repo_dir_ / "timestamp.json",
@@ -211,10 +208,8 @@ void Repo::generateRepo(KeyType key_type) {
   snapshot["_type"] = "Snapshot";
   snapshot["expires"] = expiration_time_;
   snapshot["version"] = 1;
-  snapshot["meta"]["root.json"]["hashes"]["sha256"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(signed_root)));
-  snapshot["meta"]["root.json"]["hashes"]["sha512"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(signed_root)));
+  snapshot["meta"]["root.json"]["hashes"]["sha256"] = Crypto::sha256digestHex(signed_root);
+  snapshot["meta"]["root.json"]["hashes"]["sha512"] = Crypto::sha512digestHex(signed_root);
   snapshot["meta"]["root.json"]["length"] = static_cast<Json::UInt>(signed_root.length());
   snapshot["meta"]["root.json"]["version"] = 1;
   snapshot["meta"]["targets.json"]["version"] = 1;
@@ -225,10 +220,8 @@ void Repo::generateRepo(KeyType key_type) {
   timestamp["_type"] = "Timestamp";
   timestamp["expires"] = expiration_time_;
   timestamp["version"] = 1;
-  timestamp["meta"]["snapshot.json"]["hashes"]["sha256"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(signed_snapshot)));
-  timestamp["meta"]["snapshot.json"]["hashes"]["sha512"] =
-      boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(signed_snapshot)));
+  timestamp["meta"]["snapshot.json"]["hashes"]["sha256"] = Crypto::sha256digestHex(signed_snapshot);
+  timestamp["meta"]["snapshot.json"]["hashes"]["sha512"] = Crypto::sha512digestHex(signed_snapshot);
   timestamp["meta"]["snapshot.json"]["length"] = static_cast<Json::UInt>(signed_snapshot.length());
   timestamp["meta"]["snapshot.json"]["version"] = 1;
   Utils::writeFile(repo_dir_ / "timestamp.json",

--- a/src/uptane_generator/repo.h
+++ b/src/uptane_generator/repo.h
@@ -2,10 +2,12 @@
 #define REPO_H_
 
 #include <fnmatch.h>
+#include <boost/filesystem/path.hpp>
+#include <string>
+#include <utility>
 
-#include <crypto/crypto.h>
-#include <boost/filesystem.hpp>
 #include "json/json.h"
+#include "libaktualizr/types.h"
 #include "uptane/tuf.h"
 
 struct KeyPair {

--- a/src/uptane_generator/repo_test.cc
+++ b/src/uptane_generator/repo_test.cc
@@ -5,9 +5,11 @@
 
 #include <boost/filesystem.hpp>
 
+#include "crypto/crypto.h"
 #include "libaktualizr/config.h"
 #include "logging/logging.h"
 #include "test_utils.h"
+#include "uptane/exceptions.h"
 #include "uptane_repo.h"
 
 KeyType key_type = KeyType::kED25519;
@@ -42,9 +44,9 @@ void check_repo(const TemporaryDirectory &temp_dir, const Uptane::RepositoryType
 
   const Json::Value timestamp_signed = Utils::parseJSONFile(repo_dir / "timestamp.json")["signed"];
   EXPECT_EQ(timestamp_signed["meta"]["snapshot.json"]["hashes"]["sha256"].asString(),
-            boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha256digest(snapshot_raw))));
+            Crypto::sha256digestHex(snapshot_raw));
   EXPECT_EQ(timestamp_signed["meta"]["snapshot.json"]["hashes"]["sha512"].asString(),
-            boost::algorithm::to_lower_copy(boost::algorithm::hex(Crypto::sha512digest(snapshot_raw))));
+            Crypto::sha512digestHex(snapshot_raw));
   EXPECT_EQ(timestamp_signed["meta"]["snapshot.json"]["length"].asUInt(),
             static_cast<Json::UInt>(snapshot_raw.length()));
   EXPECT_EQ(timestamp_signed["meta"]["snapshot.json"]["version"].asUInt(), snapshot_signed["version"].asUInt());

--- a/src/virtual_secondary/managedsecondary.h
+++ b/src/virtual_secondary/managedsecondary.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 #include "json/json.h"
 
 #include "libaktualizr/secondaryinterface.h"

--- a/tests/aktualizr_cycle_simple.cc
+++ b/tests/aktualizr_cycle_simple.cc
@@ -1,6 +1,4 @@
-#include <gtest/gtest.h>
-
-#include <future>
+#include <boost/filesystem.hpp>
 #include <iostream>
 #include <string>
 #include <thread>

--- a/tests/metafake.h
+++ b/tests/metafake.h
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include "logging/logging.h"
 #include "uptane_repo.h"

--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "json/json.h"
+#include <boost/filesystem.hpp>
 
 #include "libaktualizr/config.h"
 #include "libaktualizr/aktualizr.h"


### PR DESCRIPTION
Reducing what is included in headers is one way to speed up compiles. I see a
~30% reduction in built times on my laptop with these changes, which were
mostly recommendations from IWYU https://include-what-you-use.org/

Signed-off-by: Phil Wise <phil@phil-wise.com>