### PR TITLE
Fix build with gcc-12

### DIFF
--- a/include/libaktualizr/packagemanagerinterface.h
+++ b/include/libaktualizr/packagemanagerinterface.h
@@ -1,6 +1,7 @@
 #ifndef PACKAGEMANAGERINTERFACE_H_
 #define PACKAGEMANAGERINTERFACE_H_
 
+#include <fstream>
 #include <mutex>
 #include <string>
 

--- a/src/libaktualizr/storage/fsstorage_read.cc
+++ b/src/libaktualizr/storage/fsstorage_read.cc
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <fstream>
 #include <iostream>
 #include <utility>
 

--- a/src/sota_tools/ostree_ref.cc
+++ b/src/sota_tools/ostree_ref.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <boost/filesystem.hpp>
+#include <fstream>
 #include <iostream>
 #include <iterator>
 #include <utility>


### PR DESCRIPTION
* fixes:
```
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:26:17: error: field ‘fhandle’ has incomplete type ‘std::ofstream’ {aka ‘std::basic_ofstream<char>’}
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:92:71: error: ‘data’ has incomplete type
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:118:37: error: invalid use of incomplete type ‘std::ofstream’ {aka ‘class std::basic_ofstream<char>’}
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:125:56: error: invalid use of incomplete type ‘std::ifstream’ {aka ‘class std::basic_ifstream<char>’}
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:126:37: error: invalid use of incomplete type ‘std::ofstream’ {aka ‘class std::basic_ofstream<char>’}
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:131:37: error: invalid use of incomplete type ‘std::ofstream’ {aka ‘class std::basic_ofstream<char>’}
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:154:39: error: invalid use of incomplete type ‘std::ofstream’ {aka ‘class std::basic_ofstream<char>’}
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:166:37: error: invalid use of incomplete type ‘std::ofstream’ {aka ‘class std::basic_ofstream<char>’}
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:204:51: error: invalid use of incomplete type ‘std::ifstream’ {aka ‘class std::basic_ifstream<char>’}
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:244:85: error: return type ‘std::ifstream’ {aka ‘class std::basic_ifstream<char>’} is incomplete
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:249:24: error: variable ‘std::ifstream stream’ has initializer but incomplete type
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:256:85: error: return type ‘std::ofstream’ {aka ‘class std::basic_ofstream<char>’} is incomplete
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:260:24: error: variable ‘std::ofstream stream’ has initializer but incomplete type
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:268:85: error: return type ‘std::ofstream’ {aka ‘class std::basic_ofstream<char>’} is incomplete
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/package_manager/packagemanagerinterface.cc:273:24: error: variable ‘std::ofstream stream’ has initializer but incomplete type
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/libaktualizr/storage/fsstorage_read.cc:212:22: error: variable ‘std::ifstream file’ has initializer but incomplete type
aktualizr-native/1.0+gitAUTOINC+bf0494df63-7/git/src/sota_tools/ostree_ref.cc:16:20: error: variable ‘std::ifstream f’ has initializer but incomplete type
```