### PR TITLE
Improve error logging

### DIFF
--- a/src/libaktualizr/uptane/imagerepository.cc
+++ b/src/libaktualizr/uptane/imagerepository.cc
@@ -129,16 +129,20 @@ void ImageRepository::fetchTargets(INvStorage& storage, const IMetadataFetcher& 
 
 void ImageRepository::verifyRoleHashes(const std::string& role_data, const Uptane::Role& role, bool prefetch) const {
   const std::string canonical = Utils::jsonToCanonicalStr(Utils::parseJSON(role_data));
-  // Hashes are not required. If present, however, we may as well check them.
+  // Hashes are not required in snapshot metadata. If present, however, we may as well check them.
   // This provides no security benefit, but may help with fault detection.
   for (const auto& it : snapshot.role_hashes(role)) {
     switch (it.type()) {
       case Hash::Type::kSha256:
         if (Hash(Hash::Type::kSha256, Crypto::sha256digestHex(canonical)) != it) {
+          // If prefetch is true, it means we're checking a local copy of the metadata.
+          // Failures in that case just indicate we need to refresh it from the server, so
+          // we only actually log the error if the metadata comes directly from the server.
           if (!prefetch) {
             LOG_ERROR << "Hash verification for " << role << " metadata failed";
           }
-          throw Uptane::SecurityException(RepositoryType::IMAGE, "Hash metadata mismatch");
+          throw Uptane::SecurityException(RepositoryType::IMAGE,
+                                          "Snapshot hash mismatch for " + role.ToString() + " metadata");
         }
         break;
       case Hash::Type::kSha512:
@@ -146,7 +150,8 @@ void ImageRepository::verifyRoleHashes(const std::string& role_data, const Uptan
           if (!prefetch) {
             LOG_ERROR << "Hash verification for " << role << " metadata failed";
           }
-          throw Uptane::SecurityException(RepositoryType::IMAGE, "Hash metadata mismatch");
+          throw Uptane::SecurityException(RepositoryType::IMAGE,
+                                          "Snapshot hash mismatch for " + role.ToString() + " metadata");
         }
         break;
       default:
@@ -174,7 +179,11 @@ void ImageRepository::verifyTargets(const std::string& targets_raw, bool prefetc
       throw Uptane::VersionMismatch(RepositoryType::IMAGE, Uptane::Role::TARGETS);
     }
   } catch (const Exception& e) {
-    LOG_ERROR << "Signature verification for Image repo Targets metadata failed";
+    if (!prefetch) {
+      LOG_ERROR << "Verification for Image repo Targets metadata failed";
+    } else {
+      LOG_DEBUG << "Verification for local Image repo Targets metadata failed";
+    }
     throw;
   }
 }
@@ -251,7 +260,8 @@ void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fe
         fetch_snapshot = false;
         LOG_DEBUG << "Skipping Image repo Snapshot download; stored version is still current.";
       } catch (const Uptane::Exception& e) {
-        LOG_ERROR << "Image repo Snapshot verification failed: " << e.what();
+        LOG_INFO << "Downloading new Image repo Snapshot metadata because verification of local copy failed: "
+                 << e.what();
       }
       local_version = snapshot.version();
     } else {
@@ -279,7 +289,8 @@ void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fe
         fetch_targets = false;
         LOG_DEBUG << "Skipping Image repo Targets download; stored version is still current.";
       } catch (const std::exception& e) {
-        LOG_ERROR << "Image repo Target verification failed: " << e.what();
+        LOG_INFO << "Downloading new Image repo Targets metadata because verification of local copy failed: "
+                 << e.what();
       }
       if (targets) {
         local_version = targets->version();


### PR DESCRIPTION
This is mostly just scratching a personal itch in the way libaktualizr logs errors in metadata verification. Copying the commit message here by way of explanation:

> When we check local metadata, we're normally just checking that whether it needs to be refreshed from the server or not. We indicate that by passing the prefetch bool. If we encounter a verification failure in that case, it's not actually an error, so we should not be logging it as such.

I'm changing this because I'm sick of seeing a bunch of messages like these in aktualizr logs:

```
Jul 15 23:55:12 colibri-imx7-emmc-06476398 aktualizr-torizon[756]: Image repo Snapshot verification failed: Snapshot metadata hash verification failed
Jul 15 23:55:13 colibri-imx7-emmc-06476398 aktualizr-torizon[756]: Signature verification for Image repo Targets metadata failed
Jul 15 23:55:13 colibri-imx7-emmc-06476398 aktualizr-torizon[756]: Image repo Target verification failed: Hash metadata mismatch
```
They confuse end users, and make it sound like there's something wrong when it's actually just a perfectly normal update cycle.