### PR TITLE
Docs port

### DIFF
--- a/ci/gitlab/.gitlab-ci.yml
+++ b/ci/gitlab/.gitlab-ci.yml
@@ -52,6 +52,7 @@ Docker Setup:
   services:
     - docker:18-dind
   before_script:
+    - docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
     - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
   script:
     # main images
@@ -362,6 +363,7 @@ app-docker-image:
   needs: []
   allow_failure: true
   before_script:
+    - docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
     - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
   script:
     - cp ./docker/Dockerfile.aktualizr ./ci/gitlab/Dockerfile

--- a/docs/ota-client-guide/modules/ROOT/pages/rollback.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/rollback.adoc
@@ -19,7 +19,7 @@ Currently only U-boot 'bootcount' rollback mechanism is supported.
 
 == U-boot
 
-More info about bootcount feature you can find in U-boot https://www.denx.de/wiki/Knowhow/DULG/UBootBootCountLimit[documentation].
+More info about bootcount feature you can find in U-boot https://u-boot.readthedocs.io/en/latest/index.html[documentation].
 
 When using 'bootcount' the system can be in one of three states:
 

--- a/docs/ota-client-guide/modules/ROOT/pages/troubleshooting-bsp-integration.adoc
+++ b/docs/ota-client-guide/modules/ROOT/pages/troubleshooting-bsp-integration.adoc
@@ -38,6 +38,4 @@ Building an integration with a new board involves dealing with several different
 ** https://ostreedev.github.io/ostree/deployment/[Deployments]
 ** https://ostreedev.github.io/ostree/atomic-upgrades/[Atomic Upgrades]
 
-* https://www.denx.de/wiki/Knowhow/DULG/Manual[U-Boot reference documentation]
-** https://www.denx.de/wiki/Knowhow/DULG/UBootCommandLineInterface[CLI]
-** https://www.denx.de/wiki/Knowhow/DULG/UBootScripts[Scripting]
+* https://u-boot.readthedocs.io/en/latest/index.html[U-Boot reference documentation]


### PR DESCRIPTION
Porting https://github.com/advancedtelematic/aktualizr/pull/1818 and https://github.com/advancedtelematic/aktualizr/pull/1821. Debatable if really necessary here, but good to keep things in sync.