### PR TITLE
Revert "Manually fetch the submodules in github CI."

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
         -eTEST_SOTA_PACKED_CREDENTIALS=dummy-credentials
     steps:
       - uses: actions/checkout@main
-      - run: |
-          git fetch --prune --unshallow
-          git submodule update --init --recursive --force
+        with:
+          submodules: recursive
+      - run: git fetch --prune --unshallow
       - name: Docker login
         if: github.token
         run: echo ${{ github.token }} | docker login docker.pkg.github.com -u uptane --password-stdin
@@ -58,9 +58,9 @@ jobs:
         -eTEST_WITH_TESTSUITE=0
     steps:
       - uses: actions/checkout@main
-      - run: |
-          git fetch --prune --unshallow
-          git submodule update --init --recursive --force
+        with:
+          submodules: recursive
+      - run: git fetch --prune --unshallow
       - name: Docker login
         if: github.token
         run: echo ${{ github.token }} | docker login docker.pkg.github.com -u uptane --password-stdin
@@ -93,9 +93,9 @@ jobs:
         -eTEST_WITH_DOCS=1
     steps:
       - uses: actions/checkout@main
-      - run: |
-          git fetch --prune --unshallow
-          git submodule update --init --recursive --force
+        with:
+          submodules: recursive
+      - run: git fetch --prune --unshallow
       - name: Docker login
         if: github.token
         run: echo ${{ github.token }} | docker login docker.pkg.github.com -u uptane --password-stdin


### PR DESCRIPTION
This reverts commit 8a9595b5b26247b6d29d171fdb03bd28098b97a4 (from https://github.com/uptane/aktualizr/pull/73).

That commit was just a workaround because nothing else seemed to work. Now that it's merged to master and everything looks fine, let's try to remove this again and get back to "normal".