### PR TITLE
Tidy up HttpFake

### DIFF
--- a/src/aktualizr_primary/primary_secondary_registration_test.cc
+++ b/src/aktualizr_primary/primary_secondary_registration_test.cc
@@ -2,6 +2,7 @@
 
 #include "httpfake.h"
 #include "libaktualizr/aktualizr.h"
+#include "metafake.h"
 #include "secondary.h"
 #include "uptane_test_common.h"
 #include "utilities/utils.h"
@@ -127,7 +128,7 @@ int main(int argc, char** argv) {
 
   TemporaryDirectory tmp_dir;
   fake_meta_dir = tmp_dir.Path();
-  MetaFake meta_fake(fake_meta_dir);
+  CreateFakeRepoMetaData(fake_meta_dir);
 
   return RUN_ALL_TESTS();
 }

--- a/src/libaktualizr/package_manager/packagemanagerfake_test.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake_test.cc
@@ -1,12 +1,13 @@
 #include <gtest/gtest.h>
 
-#include <fstream>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 
 #include <boost/filesystem.hpp>
 
+#include "crypto/crypto.h"
 #include "crypto/keymanager.h"
 #include "httpfake.h"
 #include "libaktualizr/config.h"
@@ -14,7 +15,6 @@
 #include "package_manager/packagemanagerfake.h"
 #include "storage/invstorage.h"
 #include "uptane/fetcher.h"
-#include "uptane/tuf.h"
 #include "utilities/utils.h"
 
 // Test creating, appending and reading binary targets.

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -14,12 +14,14 @@
 #include "libaktualizr/events.h"
 
 #include "httpfake.h"
+#include "metafake.h"
 #include "primary/aktualizr_helpers.h"
 #include "primary/sotauptaneclient.h"
 #include "uptane_test_common.h"
 #include "utilities/utils.h"
 #include "virtualsecondary.h"
 
+#include "uptane_repo.h"
 #include "utilities/fault_injection.h"
 
 boost::filesystem::path uptane_repos_dir;
@@ -2365,7 +2367,7 @@ int main(int argc, char** argv) {
 
   TemporaryDirectory tmp_dir;
   fake_meta_dir = tmp_dir.Path();
-  MetaFake meta_fake(fake_meta_dir);
+  CreateFakeRepoMetaData(fake_meta_dir);
 
   return RUN_ALL_TESTS();
 }

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -1694,6 +1694,37 @@ TEST(Aktualizr, TargetAutoremove) {
   }
 }
 
+TEST(Aktualizr, MultibyteUnicodeChars) {
+  TemporaryDirectory temp_dir;
+  const boost::filesystem::path local_metadir = temp_dir / "metadir";
+  Utils::createDirectories(local_metadir, S_IRWXU);
+  auto http = std::make_shared<HttpFake>(temp_dir.Path(), "", local_metadir / "repo");
+
+  UptaneRepo repo{local_metadir, "2025-07-04T16:33:27Z", "id0"};
+  repo.generateRepo(KeyType::kED25519);
+  const std::string hwid = "primary_hw";
+  std::string target_name = "\u30C4\U0001F600.txt";
+  repo.addImage(fake_meta_dir / "fake_meta/primary_firmware.txt", target_name, hwid);
+  repo.addTarget(target_name, hwid, "CA:FE:A6:D2:84:9D");
+  repo.signTargets();
+
+  Config conf = UptaneTestCommon::makeTestConfig(temp_dir, http->tls_server);
+  auto storage = INvStorage::newStorage(conf.storage);
+  UptaneTestCommon::TestAktualizr aktualizr(conf, storage, http);
+
+  aktualizr.Initialize();
+  result::UpdateCheck update_result = aktualizr.CheckUpdates().get();
+  aktualizr.Download(update_result.updates).get();
+
+  EXPECT_EQ(aktualizr.GetStoredTargets().size(), 1);
+
+  result::Install install_result = aktualizr.Install(update_result.updates).get();
+  EXPECT_TRUE(install_result.dev_report.success);
+
+  std::vector<Uptane::Target> targets = aktualizr.GetStoredTargets();
+  ASSERT_EQ(targets.size(), 1);
+  EXPECT_EQ(targets[0].filename(), target_name);
+}
 /*
  * Initialize -> Install -> nothing to install.
  *

--- a/src/libaktualizr/primary/metadata_expiration_test.cc
+++ b/src/libaktualizr/primary/metadata_expiration_test.cc
@@ -1,7 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <boost/algorithm/hex.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 #include <string>
 
+#include "crypto/crypto.h"
 #include "httpfake.h"
 #include "libaktualizr/aktualizr.h"
 #include "test_utils.h"

--- a/src/libaktualizr/primary/metadata_fetch_test.cc
+++ b/src/libaktualizr/primary/metadata_fetch_test.cc
@@ -85,9 +85,9 @@ TEST(Aktualizr, MetadataFetch) {
 
   // Two images added, but only one update scheduled: all metadata objects
   // should be fetched once.
-  uptane_repo_.addImage("tests/test_data/firmware.txt", "firmware.txt", "primary_hw");
+  uptane_repo_.addImage("tests/test_data/firmware.txt", "firmware-małecki.txt", "primary_hw");
   uptane_repo_.addImage("tests/test_data/firmware_name.txt", "firmware_name.txt", "primary_hw");
-  uptane_repo_.addTarget("firmware.txt", "primary_hw", "CA:FE:A6:D2:84:9D");
+  uptane_repo_.addTarget("firmware-małecki.txt", "primary_hw", "CA:FE:A6:D2:84:9D");
   uptane_repo_.addDelegation(Uptane::Role("role-abc", true), Uptane::Role("targets", false), "abc/*", false,
                              KeyType::kED25519);
   uptane_repo_.signTargets();
@@ -123,7 +123,7 @@ TEST(Aktualizr, MetadataFetch) {
   // Delegation added to an existing delegation; update scheduled with
   // pre-existing image: Snapshot must be refetched, but Targets are unchanged.
   uptane_repo_.emptyTargets();
-  uptane_repo_.addTarget("firmware.txt", "primary_hw", "CA:FE:A6:D2:84:9D");
+  uptane_repo_.addTarget("firmware-małecki.txt", "primary_hw", "CA:FE:A6:D2:84:9D");
   uptane_repo_.addDelegation(Uptane::Role("role-def", true), Uptane::Role("role-abc", true), "def/*", false,
                              KeyType::kED25519);
   uptane_repo_.signTargets();

--- a/src/libaktualizr/primary/reregistration_test.cc
+++ b/src/libaktualizr/primary/reregistration_test.cc
@@ -5,6 +5,7 @@
 
 #include "httpfake.h"
 #include "libaktualizr/config.h"
+#include "metafake.h"
 #include "uptane_test_common.h"
 #include "virtualsecondary.h"
 
@@ -204,7 +205,7 @@ int main(int argc, char** argv) {
 
   TemporaryDirectory tmp_dir;
   fake_meta_dir = tmp_dir.Path();
-  MetaFake meta_fake(fake_meta_dir);
+  CreateFakeRepoMetaData(fake_meta_dir);
 
   return RUN_ALL_TESTS();
 }

--- a/src/libaktualizr/uptane/uptane_test.cc
+++ b/src/libaktualizr/uptane/uptane_test.cc
@@ -13,6 +13,7 @@
 #include <boost/filesystem.hpp>
 #include "json/json.h"
 
+#include "crypto/crypto.h"
 #include "crypto/p11engine.h"
 #include "httpfake.h"
 #include "libaktualizr/secondaryinterface.h"

--- a/src/virtual_secondary/virtual_secondary_test.cc
+++ b/src/virtual_secondary/virtual_secondary_test.cc
@@ -2,6 +2,7 @@
 
 #include "httpfake.h"
 #include "libaktualizr/secondaryinterface.h"
+#include "uptane_repo.h"
 #include "uptane_test_common.h"
 #include "utilities/utils.h"
 #include "virtualsecondary.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,7 +52,8 @@ set(TEST_SOURCES httpfake.h metafake.h test_utils.cc test_utils.h uptane_vector_
 
 include(CMakeParseArguments)
 
-add_library(testutilities STATIC test_utils.cc)
+add_library(testutilities STATIC httpfake.cc metafake.cc test_utils.cc)
+target_link_libraries(testutilities uptane_generator_lib)
 
 if(BUILD_OSTREE)
     add_library(ostree_mock SHARED ostree_mock.c)

--- a/tests/httpfake.cc
+++ b/tests/httpfake.cc
@@ -1,0 +1,122 @@
+#include "httpfake.h"
+
+#include <iostream>
+#include <boost/filesystem.hpp>
+#include <curl/curl.h>  // curl_easy_unescape
+#include <boost/algorithm/hex.hpp>
+#include <boost/algorithm/string.hpp>
+#include <thread>
+#include <chrono>
+
+#include "logging/logging.h"
+
+#include "metafake.h"
+
+HttpFake::HttpFake(boost::filesystem::path test_dir_in, std::string flavor,
+                  boost::filesystem::path meta_dir_in)
+    : test_dir(std::move(test_dir_in)), flavor_(std::move(flavor)), meta_dir(std::move(meta_dir_in)) {
+  if (meta_dir.empty()) {
+    meta_dir = temp_meta_dir.Path();
+    CreateFakeRepoMetaData(meta_dir);
+  }
+}
+
+bool HttpFake::rewrite(std::string &url, const std::string &pattern) const {
+  size_t pat_pos = url.find(pattern);
+  if (pat_pos == std::string::npos) {
+    return false;
+  }
+  size_t ext_pos = pattern.find(".json");
+  if (ext_pos == std::string::npos) {
+    LOG_ERROR << "Invalid pattern";
+    url = "";
+    return false;
+  }
+
+  url.replace(pat_pos + ext_pos, std::string(".json").size(), "_" + flavor_ + ".json");
+  return true;
+}
+
+HttpResponse HttpFake::get(const std::string &url, int64_t maxsize) {
+  (void)maxsize;
+  std::cout << "URL requested: " << url << "\n";
+
+  std::string new_url = url;
+  if (!flavor_.empty()) {
+    rewrite(new_url, "director/targets.json") || rewrite(new_url, "repo/timestamp.json") ||
+        rewrite(new_url, "repo/targets.json") || rewrite(new_url, "snapshot.json");
+
+    if (new_url != url) {
+      std::cout << "Rewritten to: " << new_url << "\n";
+    }
+  }
+
+  const boost::filesystem::path path = meta_dir / new_url.substr(tls_server.size());
+
+  std::cout << "file served: " << path << "\n";
+
+  if (boost::filesystem::exists(path)) {
+    return HttpResponse(Utils::readFile(path), 200, CURLE_OK, "");
+  } else {
+    std::cout << "not found: " << path << "\n";
+    return HttpResponse({}, 404, CURLE_OK, "");
+  }
+}
+
+HttpResponse HttpFake::post(const std::string &url, const Json::Value &data) {
+  if (url.find("/devices") != std::string::npos || url.find("/director/ecus") != std::string::npos || url.empty()) {
+    Utils::writeFile((test_dir / "post.json").string(), data);
+    return HttpResponse(Utils::readFile("tests/test_data/cred.p12"), 200, CURLE_OK, "");
+  } else if (url.find("/events") != std::string::npos) {
+    return handle_event(url, data);
+  }
+  return HttpResponse("", 400, CURLE_OK, "");
+}
+
+std::future<HttpResponse> HttpFake::downloadAsync(const std::string &url, curl_write_callback write_cb,
+                                        curl_xferinfo_callback progress_cb, void *userp, curl_off_t from,
+                                        CurlHandler *easyp) {
+  (void)userp;
+  (void)from;
+  (void)easyp;
+  (void)progress_cb;
+
+  std::cout << "URL requested: " << url << "\n";
+  std::string path_segment = url.substr(tls_server.size());
+
+  int fn_length;
+  char *fn = curl_easy_unescape(nullptr, path_segment.data(), static_cast<int>(path_segment.size()), &fn_length);
+  if (fn == nullptr) {
+    std::cout << "Could not decode url. Trying it un-decoded\n";
+  } else {
+    path_segment.clear();
+    path_segment.append(fn, static_cast<size_t>(fn_length));
+    curl_free(fn);
+  }
+  const boost::filesystem::path path = meta_dir / path_segment;
+  std::cout << "file served: " << path << "\n";
+
+  std::promise<HttpResponse> resp_promise;
+  auto resp_future = resp_promise.get_future();
+  std::thread(
+      [path, write_cb, progress_cb, userp, url](std::promise<HttpResponse> promise) {
+        if (!boost::filesystem::exists(path)) {
+          std::cout << "File not found on disk!\n";
+          promise.set_value(HttpResponse("", 404, CURLE_OK, ""));
+          return;
+        }
+        const std::string content = Utils::readFile(path.string());
+        for (unsigned int i = 0; i < content.size(); ++i) {
+          write_cb(const_cast<char *>(&content[i]), 1, 1, userp);
+          progress_cb(userp, 0, 0, 0, 0);
+          if (url.find("downloads/repo/targets/primary_firmware.txt") != std::string::npos) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));  // Simulate big file
+          }
+        }
+        promise.set_value(HttpResponse(content, 200, CURLE_OK, ""));
+      },
+      std::move(resp_promise))
+      .detach();
+
+  return resp_future;
+}

--- a/tests/httpfake.h
+++ b/tests/httpfake.h
@@ -1,34 +1,19 @@
 #ifndef HTTPFAKE_H_
 #define HTTPFAKE_H_
 
-#include <boost/algorithm/hex.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
-#include <chrono>
-#include <fstream>
+#include <boost/filesystem/path.hpp>
 #include <string>
-#include <thread>
 
 #include "json/json.h"
 
-#include <curl/curl.h>  // curl_easy_unescape
-#include "crypto/crypto.h"
 #include "http/httpinterface.h"
-#include "logging/logging.h"
-#include "metafake.h"
 #include "utilities/utils.h"
 
 class HttpFake : public HttpInterface {
  public:
   // old style HttpFake with centralized multi repo and url rewriting
   explicit HttpFake(boost::filesystem::path test_dir_in, std::string flavor = "",
-                    boost::filesystem::path meta_dir_in = "")
-      : test_dir(std::move(test_dir_in)), flavor_(std::move(flavor)), meta_dir(std::move(meta_dir_in)) {
-    if (meta_dir.empty()) {
-      meta_dir = temp_meta_dir.Path();
-      MetaFake meta(meta_dir);
-    }
-  }
+                    boost::filesystem::path meta_dir_in = "");
 
   ~HttpFake() override = default;
 
@@ -43,21 +28,7 @@ class HttpFake : public HttpInterface {
   }
 
   // rewrite xxx/yyy.json to xxx/yyy_flavor.json
-  bool rewrite(std::string &url, const std::string &pattern) {
-    size_t pat_pos = url.find(pattern);
-    if (pat_pos == std::string::npos) {
-      return false;
-    }
-    size_t ext_pos = pattern.find(".json");
-    if (ext_pos == std::string::npos) {
-      LOG_ERROR << "Invalid pattern";
-      url = "";
-      return false;
-    }
-
-    url.replace(pat_pos + ext_pos, std::string(".json").size(), "_" + flavor_ + ".json");
-    return true;
-  }
+  bool rewrite(std::string &url, const std::string &pattern) const;
 
   virtual HttpResponse handle_event(const std::string &url, const Json::Value &data) {
     (void)url;
@@ -66,31 +37,7 @@ class HttpFake : public HttpInterface {
     return HttpResponse("", 400, CURLE_OK, "");
   }
 
-  HttpResponse get(const std::string &url, int64_t maxsize) override {
-    (void)maxsize;
-    std::cout << "URL requested: " << url << "\n";
-
-    std::string new_url = url;
-    if (!flavor_.empty()) {
-      rewrite(new_url, "director/targets.json") || rewrite(new_url, "repo/timestamp.json") ||
-          rewrite(new_url, "repo/targets.json") || rewrite(new_url, "snapshot.json");
-
-      if (new_url != url) {
-        std::cout << "Rewritten to: " << new_url << "\n";
-      }
-    }
-
-    const boost::filesystem::path path = meta_dir / new_url.substr(tls_server.size());
-
-    std::cout << "file served: " << path << "\n";
-
-    if (boost::filesystem::exists(path)) {
-      return HttpResponse(Utils::readFile(path), 200, CURLE_OK, "");
-    } else {
-      std::cout << "not found: " << path << "\n";
-      return HttpResponse({}, 404, CURLE_OK, "");
-    }
-  }
+  HttpResponse get(const std::string &url, int64_t maxsize) override;
 
   HttpResponse post(const std::string &url, const std::string &content_type, const std::string &data) override {
     (void)url;
@@ -99,15 +46,7 @@ class HttpFake : public HttpInterface {
     return HttpResponse({}, 200, CURLE_OK, "");
   }
 
-  HttpResponse post(const std::string &url, const Json::Value &data) override {
-    if (url.find("/devices") != std::string::npos || url.find("/director/ecus") != std::string::npos || url.empty()) {
-      Utils::writeFile((test_dir / "post.json").string(), data);
-      return HttpResponse(Utils::readFile("tests/test_data/cred.p12"), 200, CURLE_OK, "");
-    } else if (url.find("/events") != std::string::npos) {
-      return handle_event(url, data);
-    }
-    return HttpResponse("", 400, CURLE_OK, "");
-  }
+  HttpResponse post(const std::string &url, const Json::Value &data) override;
 
   HttpResponse put(const std::string &url, const std::string &content_type, const std::string &data) override {
     (void)url;
@@ -123,51 +62,7 @@ class HttpFake : public HttpInterface {
 
   std::future<HttpResponse> downloadAsync(const std::string &url, curl_write_callback write_cb,
                                           curl_xferinfo_callback progress_cb, void *userp, curl_off_t from,
-                                          CurlHandler *easyp) override {
-    (void)userp;
-    (void)from;
-    (void)easyp;
-    (void)progress_cb;
-
-    std::cout << "URL requested: " << url << "\n";
-    std::string path_segment = url.substr(tls_server.size());
-
-    int fn_length;
-    char *fn = curl_easy_unescape(nullptr, path_segment.data(), static_cast<int>(path_segment.size()), &fn_length);
-    if (fn == nullptr) {
-      std::cout << "Could not decode url. Trying it un-decoded\n";
-    } else {
-      path_segment.clear();
-      path_segment.append(fn, static_cast<size_t>(fn_length));
-      curl_free(fn);
-    }
-    const boost::filesystem::path path = meta_dir / path_segment;
-    std::cout << "file served: " << path << "\n";
-
-    std::promise<HttpResponse> resp_promise;
-    auto resp_future = resp_promise.get_future();
-    std::thread(
-        [path, write_cb, progress_cb, userp, url](std::promise<HttpResponse> promise) {
-          if (!boost::filesystem::exists(path)) {
-            std::cout << "File not found on disk!\n";
-            promise.set_value(HttpResponse("", 404, CURLE_OK, ""));
-            return;
-          }
-          const std::string content = Utils::readFile(path.string());
-          for (unsigned int i = 0; i < content.size(); ++i) {
-            write_cb(const_cast<char *>(&content[i]), 1, 1, userp);
-            progress_cb(userp, 0, 0, 0, 0);
-            if (url.find("downloads/repo/targets/primary_firmware.txt") != std::string::npos) {
-              std::this_thread::sleep_for(std::chrono::milliseconds(100));  // Simulate big file
-            }
-          }
-          promise.set_value(HttpResponse(content, 200, CURLE_OK, ""));
-        },
-        std::move(resp_promise))
-        .detach();
-
-    return resp_future;
-  }
+                                          CurlHandler *easyp) override;
 
   HttpResponse download(const std::string &url, curl_write_callback write_cb, curl_xferinfo_callback progress_cb,
                         void *userp, curl_off_t from) override {

--- a/tests/metafake.cc
+++ b/tests/metafake.cc
@@ -1,0 +1,137 @@
+#include "metafake.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+
+#include "uptane_repo.h"
+#include "utilities/utils.h"
+
+namespace {
+// Extracted out of metafake.h
+class MetaFake {
+ public:
+  explicit MetaFake(boost::filesystem::path meta_dir_in)
+      : meta_dir(std::move(meta_dir_in)),
+        work_dir(meta_dir / "fake_meta"),
+        repo(work_dir, "2025-07-04T16:33:27Z", "id0") {
+    repo.generateRepo(KeyType::kED25519);
+    backup();
+    create_image();
+    create_testData();
+  }
+
+ private:
+  void create_testData(void) {
+    boost::filesystem::path file_name;
+    std::string hwid;
+
+    // add image for "has update" metadata
+    file_name = "dummy_firmware.txt";
+    repo.addImage(work_dir / file_name, file_name, "dummy");
+
+    file_name = "primary_firmware.txt";
+    hwid = "primary_hw";
+    repo.addImage(work_dir / file_name, file_name, hwid);
+    repo.addTarget(file_name.string(), hwid, "CA:FE:A6:D2:84:9D");
+
+    file_name = "secondary_firmware.txt";
+    hwid = "secondary_hw";
+    repo.addImage(work_dir / file_name, file_name, hwid);
+    repo.addTarget(file_name.string(), hwid, "secondary_ecu_serial");
+
+    repo.signTargets();
+    rename("_hasupdates");
+
+    // add image for "no update" metadata
+    restore();
+
+    file_name = "dummy_firmware.txt";
+    repo.addImage(work_dir / file_name, file_name, "dummy");
+
+    repo.signTargets();
+    rename("_noupdates");
+
+    // add image for "multi secondary ecu" metadata
+    restore();
+
+    file_name = "dummy_firmware.txt";
+    repo.addImage(work_dir / file_name, file_name, "dummy");
+
+    file_name = "secondary_firmware.txt";
+    hwid = "sec_hw1";
+    repo.addImage(work_dir / file_name, file_name, hwid);
+    repo.addTarget(file_name.string(), hwid, "sec_serial1");
+
+    file_name = "secondary_firmware2.txt";
+    hwid = "sec_hw2";
+    repo.addImage(work_dir / file_name, file_name, hwid);
+    repo.addTarget(file_name.string(), hwid, "sec_serial2");
+
+    repo.signTargets();
+    rename("_multisec");
+
+    // copy metadata to work_dir
+    Utils::copyDir(work_dir / ImageRepo::dir, meta_dir / "repo");
+    Utils::copyDir(work_dir / DirectorRepo::dir, meta_dir / "director");
+    if (!boost::filesystem::exists(meta_dir / "campaigner") &&
+        boost::filesystem::is_directory("tests/test_data/campaigner")) {
+      Utils::copyDir("tests/test_data/campaigner", meta_dir / "campaigner");
+    }
+  }
+
+  void create_image(void) {
+    std::string content = "Just to increment timestamp, ignore it\n";
+    Utils::writeFile(work_dir / "dummy_firmware.txt", content);
+    content = "This is a dummy firmware file (should never be downloaded)\n";
+    Utils::writeFile(work_dir / "primary_firmware.txt", content);
+    content = "This is content";
+    Utils::writeFile(work_dir / "secondary_firmware.txt", content);
+    content = "This is more content\n";
+    Utils::writeFile(work_dir / "secondary_firmware2.txt", content);
+  }
+
+  void backup(void) {
+    backup_files.push_back(work_dir / DirectorRepo::dir / "targets.json");
+    backup_content.push_back(Utils::readFile(backup_files[0], false));
+
+    backup_files.push_back(work_dir / ImageRepo::dir / "snapshot.json");
+    backup_content.push_back(Utils::readFile(backup_files[1], false));
+
+    backup_files.push_back(work_dir / ImageRepo::dir / "targets.json");
+    backup_content.push_back(Utils::readFile(backup_files[2], false));
+
+    backup_files.push_back(work_dir / ImageRepo::dir / "timestamp.json");
+    backup_content.push_back(Utils::readFile(backup_files[3], false));
+  }
+
+  void restore(void) {
+    for (unsigned int i = 0; i < backup_files.size(); i++) {
+      Utils::writeFile(backup_files[i], backup_content[i]);
+    }
+  }
+
+  void rename(const std::string &appendix) {
+    for (unsigned int i = 0; i < backup_files.size(); i++) {
+      boost::filesystem::rename(backup_files[i],
+                                (backup_files[i].parent_path() / backup_files[i].stem()).string() + appendix + ".json");
+    }
+  }
+
+ private:
+  boost::filesystem::path meta_dir;
+  boost::filesystem::path work_dir;
+  UptaneRepo repo;
+  std::vector<boost::filesystem::path> backup_files;
+  std::vector<std::string> backup_content;
+};
+
+};
+
+// This is the main entry point
+void CreateFakeRepoMetaData(boost::filesystem::path meta_dir) {
+  MetaFake fake(std::move(meta_dir));
+}

--- a/tests/metafake.h
+++ b/tests/metafake.h
@@ -1,133 +1,13 @@
 #ifndef METAFAKE_H_
 #define METAFAKE_H_
 
-#include <fstream>
-#include <string>
-#include <utility>
-#include <vector>
-
 #include <boost/filesystem/path.hpp>
 
-#include "logging/logging.h"
-#include "uptane_repo.h"
-#include "utilities/utils.h"
-
-class MetaFake {
- public:
-  explicit MetaFake(boost::filesystem::path meta_dir_in)
-      : meta_dir(std::move(meta_dir_in)),
-        work_dir(meta_dir / "fake_meta"),
-        repo(work_dir, "2025-07-04T16:33:27Z", "id0") {
-    repo.generateRepo(KeyType::kED25519);
-    backup();
-    create_image();
-    create_testData();
-  }
-
- private:
-  void create_testData(void) {
-    boost::filesystem::path file_name;
-    std::string hwid;
-
-    // add image for "has update" metadata
-    file_name = "dummy_firmware.txt";
-    repo.addImage(work_dir / file_name, file_name, "dummy");
-
-    file_name = "primary_firmware.txt";
-    hwid = "primary_hw";
-    repo.addImage(work_dir / file_name, file_name, hwid);
-    repo.addTarget(file_name.string(), hwid, "CA:FE:A6:D2:84:9D");
-
-    file_name = "secondary_firmware.txt";
-    hwid = "secondary_hw";
-    repo.addImage(work_dir / file_name, file_name, hwid);
-    repo.addTarget(file_name.string(), hwid, "secondary_ecu_serial");
-
-    repo.signTargets();
-    rename("_hasupdates");
-
-    // add image for "no update" metadata
-    restore();
-
-    file_name = "dummy_firmware.txt";
-    repo.addImage(work_dir / file_name, file_name, "dummy");
-
-    repo.signTargets();
-    rename("_noupdates");
-
-    // add image for "multi secondary ecu" metadata
-    restore();
-
-    file_name = "dummy_firmware.txt";
-    repo.addImage(work_dir / file_name, file_name, "dummy");
-
-    file_name = "secondary_firmware.txt";
-    hwid = "sec_hw1";
-    repo.addImage(work_dir / file_name, file_name, hwid);
-    repo.addTarget(file_name.string(), hwid, "sec_serial1");
-
-    file_name = "secondary_firmware2.txt";
-    hwid = "sec_hw2";
-    repo.addImage(work_dir / file_name, file_name, hwid);
-    repo.addTarget(file_name.string(), hwid, "sec_serial2");
-
-    repo.signTargets();
-    rename("_multisec");
-
-    // copy metadata to work_dir
-    Utils::copyDir(work_dir / ImageRepo::dir, meta_dir / "repo");
-    Utils::copyDir(work_dir / DirectorRepo::dir, meta_dir / "director");
-    if (!boost::filesystem::exists(meta_dir / "campaigner") &&
-        boost::filesystem::is_directory("tests/test_data/campaigner")) {
-      Utils::copyDir("tests/test_data/campaigner", meta_dir / "campaigner");
-    }
-  }
-
-  void create_image(void) {
-    std::string content = "Just to increment timestamp, ignore it\n";
-    Utils::writeFile(work_dir / "dummy_firmware.txt", content);
-    content = "This is a dummy firmware file (should never be downloaded)\n";
-    Utils::writeFile(work_dir / "primary_firmware.txt", content);
-    content = "This is content";
-    Utils::writeFile(work_dir / "secondary_firmware.txt", content);
-    content = "This is more content\n";
-    Utils::writeFile(work_dir / "secondary_firmware2.txt", content);
-  }
-
-  void backup(void) {
-    backup_files.push_back(work_dir / DirectorRepo::dir / "targets.json");
-    backup_content.push_back(Utils::readFile(backup_files[0], false));
-
-    backup_files.push_back(work_dir / ImageRepo::dir / "snapshot.json");
-    backup_content.push_back(Utils::readFile(backup_files[1], false));
-
-    backup_files.push_back(work_dir / ImageRepo::dir / "targets.json");
-    backup_content.push_back(Utils::readFile(backup_files[2], false));
-
-    backup_files.push_back(work_dir / ImageRepo::dir / "timestamp.json");
-    backup_content.push_back(Utils::readFile(backup_files[3], false));
-  }
-
-  void restore(void) {
-    for (unsigned int i = 0; i < backup_files.size(); i++) {
-      Utils::writeFile(backup_files[i], backup_content[i]);
-    }
-  }
-
-  void rename(const std::string &appendix) {
-    for (unsigned int i = 0; i < backup_files.size(); i++) {
-      boost::filesystem::rename(backup_files[i],
-                                (backup_files[i].parent_path() / backup_files[i].stem()).string() + appendix + ".json");
-    }
-  }
-
- private:
-  boost::filesystem::path meta_dir;
-  boost::filesystem::path work_dir;
-  UptaneRepo repo;
-  std::vector<boost::filesystem::path> backup_files;
-  std::vector<std::string> backup_content;
-};
+/**
+ * Fill a directory with fake Uptane metadata
+ * @param meta_dir
+ */
+void CreateFakeRepoMetaData(boost::filesystem::path meta_dir);
 
 #endif  // METAFAKE_H
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -19,6 +19,7 @@ from threading import Thread
 from fake_http_server.fake_test_server import FakeTestServerBackground
 from sota_tools.treehub_server import create_repo
 from shutil import copyfileobj
+from random import randint
 
 
 logger = logging.getLogger(__name__)
@@ -37,10 +38,12 @@ class CopyThread(Thread):
 class Aktualizr:
 
     def __init__(self, aktualizr_primary_exe, aktualizr_info_exe, id,
-                 uptane_server, wait_port=9040, wait_timeout=60, log_level=1,
+                 uptane_server, wait_port=None, wait_timeout=60, log_level=1,
                  primary_port=None, secondaries=None, secondary_wait_sec=600, output_logs=True,
                  run_mode='once', director=None, image_repo=None,
                  sysroot=None, treehub=None, ostree_mock_path=None, **kwargs):
+        if wait_port is None:
+            wait_port = randint(9040, 9540)
         self.id = id
         self._aktualizr_primary_exe = aktualizr_primary_exe
         self._aktualizr_info_exe = aktualizr_info_exe


### PR DESCRIPTION
I've been looking into a problem with targets that contain non-ascii characters.  While doing the investigation work, I tidied up a few places, which formed this PR.

For background, Aktualizr and libtuf have different ideas about how to canonicalise JSON. The details are in my [multibyte](https://github.com/cajun-rat/aktualizr/tree/multibyte) branch, with [this commit](https://github.com/uptane/aktualizr/commit/271e6a04394c1e6319a0663b0de0fbed2687c54dl) being the critical one that would change things.

For now, I hope these changes are benign and will be useful in general. 