### PR TITLE
aktualizr: fix build error 'uint8_t' does not name a type

### DIFF
--- a/src/libaktualizr-posix/asn1/asn1-cer.h
+++ b/src/libaktualizr-posix/asn1/asn1-cer.h
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <cstdint>
 
 // Limitations:
 //   - Maximal supported integer width of 32 bits


### PR DESCRIPTION
My environment:
meta-updater: master branch [c10f9f]
yocto poky: master branch [303421]
ARCH: arm64

When I take :
    bitbake aktualizr

Output error said :
    uint8_t does not name a type

Add the header file cstdint to asn1-cer.h to fix it.