### PR TITLE
aktualizr: fix build error 'uint8_t' does not name a type [V2]

### DIFF
--- a/src/libaktualizr-posix/asn1/asn1-cer.h
+++ b/src/libaktualizr-posix/asn1/asn1-cer.h
@@ -1,6 +1,7 @@
 #ifndef ASN1_CER_H
 #define ASN1_CER_H
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 


### PR DESCRIPTION
My environment:
meta-updater: master branch [c10f9f]
yocto poky: master branch [303421]
ARCH: arm64

When I take :
    bitbake aktualizr

Output error said :
    uint8_t does not name a type

Add the header file cstdint to asn1-cer.h to fix it.