### PR TITLE
Introduce finer-grained cancellation of operations

### DIFF
--- a/include/libaktualizr/secondaryinterface.h
+++ b/include/libaktualizr/secondaryinterface.h
@@ -27,8 +27,20 @@ class SecondaryInterface {
   virtual int32_t getRootVersion(bool director) const = 0;
   virtual data::InstallationResult putRoot(const std::string& root, bool director) = 0;
 
-  virtual data::InstallationResult sendFirmware(const Uptane::Target& target) = 0;
-  virtual data::InstallationResult install(const Uptane::Target& target) = 0;
+  /**
+   * Send firmware to a device. This operation should be both idempotent and
+   * not commit to installing the new version. Where practical, the
+   * implementation should pre-flight the installation and report errors now,
+   * while the entire installation can be cleanly aborted.
+   * Failures reported later (during SecondaryInterface::install()) can leave
+   * a multi-ecu update partially applied.
+   */
+  virtual data::InstallationResult sendFirmware(const Uptane::Target& target,
+                                                const api::FlowControlToken* flow_control) = 0;
+  /**
+   * Commit to installing an update.
+   */
+  virtual data::InstallationResult install(const Uptane::Target& target, const api::FlowControlToken* flow_control) = 0;
 
  protected:
   SecondaryInterface(const SecondaryInterface&) = default;

--- a/include/libaktualizr/types.h
+++ b/include/libaktualizr/types.h
@@ -249,6 +249,8 @@ struct ResultCode {
     kNeedCompletion = 21,
     // Customer specific
     kCustomError = 22,
+    // The operation was explicitly cancelled, either by an offline update or explicit user choice
+    kOperationCancelled = 23,
     // Unknown
     kUnknown = -1,
   };

--- a/src/aktualizr_get/get.cc
+++ b/src/aktualizr_get/get.cc
@@ -10,7 +10,7 @@ std::string aktualizrGet(Config &config, const std::string &url, const std::vect
   auto client = std_::make_unique<HttpClient>(&headers);
   KeyManager keys(storage, config.keymanagerConfig());
   keys.copyCertsToCurl(*client);
-  auto resp = client->get(url, HttpInterface::kNoLimit);
+  auto resp = client->get(url, HttpInterface::kNoLimit, nullptr);
   if (resp.http_status_code != 200) {
     throw std::runtime_error("Unable to get " + url + ": HTTP_" + std::to_string(resp.http_status_code) + "\n" +
                              resp.body);

--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -83,7 +83,7 @@ data::InstallationResult AktualizrSecondary::verifyMetadata(const Uptane::Second
     // 4. NOT SUPPORTED: Download and check the Snapshot metadata file from the Director repository.
     // 5. Download and check the Targets metadata file from the Director repository.
     try {
-      director_repo_.updateMeta(*storage_, metadata);
+      director_repo_.updateMeta(*storage_, metadata, nullptr);
     } catch (const std::exception& e) {
       LOG_ERROR << "Failed to update Director metadata: " << e.what();
       return data::InstallationResult(data::ResultCode::Numeric::kVerificationFailed,
@@ -96,7 +96,7 @@ data::InstallationResult AktualizrSecondary::verifyMetadata(const Uptane::Second
   // 8. Download and check the Snapshot metadata file from the Image repository.
   // 9. Download and check the top-level Targets metadata file from the Image repository.
   try {
-    image_repo_.updateMeta(*storage_, metadata);
+    image_repo_.updateMeta(*storage_, metadata, nullptr);
   } catch (const std::exception& e) {
     LOG_ERROR << "Failed to update Image repo metadata: " << e.what();
     return data::InstallationResult(data::ResultCode::Numeric::kVerificationFailed,

--- a/src/aktualizr_secondary/secondary_rpc_test.cc
+++ b/src/aktualizr_secondary/secondary_rpc_test.cc
@@ -583,7 +583,8 @@ class SecondaryRpcCommon : public ::testing::Test {
       verifyMetadata(secondary_.metadata());
     }
 
-    result = ip_secondary_->sendFirmware(target);
+    // Cancelling not supported at the moment
+    result = ip_secondary_->sendFirmware(target, nullptr);
     if (handler_version == HandlerVersion::kV2Failure) {
       EXPECT_EQ(result.result_code, data::ResultCode::Numeric::kDownloadFailed);
       EXPECT_EQ(result.description, secondary_.upload_data_failure);
@@ -591,7 +592,7 @@ class SecondaryRpcCommon : public ::testing::Test {
       EXPECT_TRUE(result.isSuccess());
     }
 
-    result = ip_secondary_->install(target);
+    result = ip_secondary_->install(target, nullptr);
     if (handler_version == HandlerVersion::kV2Failure) {
       EXPECT_EQ(result.result_code, data::ResultCode::Numeric::kInstallFailed);
       EXPECT_EQ(result.description, secondary_.installation_failure);
@@ -617,7 +618,8 @@ class SecondaryRpcCommon : public ::testing::Test {
       verifyMetadata(secondary_.metadata());
     }
 
-    result = ip_secondary_->sendFirmware(target);
+    // Cancelling not supported at the moment
+    result = ip_secondary_->sendFirmware(target, nullptr);
     if (handler_version == HandlerVersion::kV2Failure) {
       EXPECT_EQ(result.result_code, data::ResultCode::Numeric::kDownloadFailed);
       EXPECT_EQ(result.description, secondary_.ostree_failure);
@@ -625,7 +627,7 @@ class SecondaryRpcCommon : public ::testing::Test {
       EXPECT_TRUE(result.isSuccess());
     }
 
-    result = ip_secondary_->install(target);
+    result = ip_secondary_->install(target, nullptr);
     if (handler_version == HandlerVersion::kV2Failure) {
       EXPECT_EQ(result.result_code, data::ResultCode::Numeric::kInstallFailed);
       EXPECT_EQ(result.description, secondary_.installation_failure);
@@ -810,8 +812,8 @@ TEST(SecondaryTcpServer, TestIpSecondaryIfSecondaryIsNotRunning) {
   EXPECT_FALSE(ip_secondary->putRoot("director-root-v2", true).isSuccess());
   EXPECT_FALSE(ip_secondary->putRoot("image-root-v2", false).isSuccess());
   EXPECT_FALSE(ip_secondary->putMetadata(target).isSuccess());
-  EXPECT_FALSE(ip_secondary->sendFirmware(target).isSuccess());
-  EXPECT_FALSE(ip_secondary->install(target).isSuccess());
+  EXPECT_FALSE(ip_secondary->sendFirmware(target, nullptr).isSuccess());
+  EXPECT_FALSE(ip_secondary->install(target, nullptr).isSuccess());
 }
 
 /* This class returns a positive result for every message. The test cases verify

--- a/src/libaktualizr-posix/asn1/messages/ipuptane_message.asn1
+++ b/src/libaktualizr-posix/asn1/messages/ipuptane_message.asn1
@@ -27,6 +27,7 @@ IpUptane DEFINITIONS ::= BEGIN
     generalError(19),
     needCompletion(21),
     customError(22),
+    operationCancelled(23),
     unknown(-1),
     ...
   }

--- a/src/libaktualizr-posix/ipuptanesecondary.cc
+++ b/src/libaktualizr-posix/ipuptanesecondary.cc
@@ -12,6 +12,7 @@
 #include "libaktualizr/secondary_provider.h"
 #include "logging/logging.h"
 #include "uptane/tuf.h"
+#include "utilities/flow_control.h"
 #include "utilities/utils.h"
 
 namespace Uptane {
@@ -358,18 +359,23 @@ bool IpUptaneSecondary::ping() const {
   return resp->present() == AKIpUptaneMes_PR_getInfoResp;
 }
 
-data::InstallationResult IpUptaneSecondary::sendFirmware(const Uptane::Target& target) {
-  data::InstallationResult send_result;
-  if (protocol_version == 2) {
-    send_result = sendFirmware_v2(target);
-  } else if (protocol_version == 1) {
-    send_result = sendFirmware_v1(target);
-  } else {
-    LOG_ERROR << "Unexpected protocol version: " << protocol_version;
-    send_result = data::InstallationResult(data::ResultCode::Numeric::kInternalError,
-                                           "Unexpected protocol version: " + std::to_string(protocol_version));
+data::InstallationResult IpUptaneSecondary::sendFirmware(const Uptane::Target& target,
+                                                         const api::FlowControlToken* flow_control) {
+  if (flow_control != nullptr && flow_control->hasAborted()) {
+    // TODO: Add an abort message to the IPUptane protocol and allow aborts
+    // during firmware transfer
+    return data::InstallationResult(data::ResultCode::Numeric::kOperationCancelled, "");
   }
-  return send_result;
+
+  if (protocol_version == 2) {
+    return sendFirmware_v2(target);
+  }
+  if (protocol_version == 1) {
+    return sendFirmware_v1(target);
+  }
+  LOG_ERROR << "Unexpected protocol version: " << protocol_version;
+  return data::InstallationResult(data::ResultCode::Numeric::kInternalError,
+                                  "Unexpected protocol version: " + std::to_string(protocol_version));
 }
 
 data::InstallationResult IpUptaneSecondary::sendFirmware_v1(const Uptane::Target& target) {
@@ -416,7 +422,14 @@ data::InstallationResult IpUptaneSecondary::sendFirmware_v2(const Uptane::Target
   }
 }
 
-data::InstallationResult IpUptaneSecondary::install(const Uptane::Target& target) {
+data::InstallationResult IpUptaneSecondary::install(const Uptane::Target& target,
+                                                    const api::FlowControlToken* flow_control) {
+  if (flow_control != nullptr && flow_control->hasAborted()) {
+    // TODO: Add an abort message to the IPUptane protocol and allow aborts
+    // during installation
+    return data::InstallationResult(data::ResultCode::Numeric::kOperationCancelled, "");
+  }
+
   data::InstallationResult install_result;
   if (protocol_version == 2) {
     install_result = install_v2(target);

--- a/src/libaktualizr-posix/ipuptanesecondary.h
+++ b/src/libaktualizr-posix/ipuptanesecondary.h
@@ -36,8 +36,9 @@ class IpUptaneSecondary : public SecondaryInterface {
   data::InstallationResult putRoot(const std::string& root, bool director) override;
   Manifest getManifest() const override;
   bool ping() const override;
-  data::InstallationResult sendFirmware(const Uptane::Target& target) override;
-  data::InstallationResult install(const Uptane::Target& target) override;
+  data::InstallationResult sendFirmware(const Uptane::Target& target,
+                                        const api::FlowControlToken* flow_control) override;
+  data::InstallationResult install(const Uptane::Target& target, const api::FlowControlToken* flow_control) override;
 
  private:
   const std::pair<std::string, uint16_t>& getAddr() const { return addr_; }

--- a/src/libaktualizr/http/httpclient.h
+++ b/src/libaktualizr/http/httpclient.h
@@ -32,7 +32,7 @@ class HttpClient : public HttpInterface {
   HttpClient(HttpClient &&) = default;
   HttpClient &operator=(const HttpClient &) = delete;
   HttpClient &operator=(HttpClient &&) = default;
-  HttpResponse get(const std::string &url, int64_t maxsize) override;
+  HttpResponse get(const std::string &url, int64_t maxsize, const api::FlowControlToken *flow_control) override;
   HttpResponse post(const std::string &url, const std::string &content_type, const std::string &data) override;
   HttpResponse post(const std::string &url, const Json::Value &data) override;
   HttpResponse put(const std::string &url, const std::string &content_type, const std::string &data) override;

--- a/src/libaktualizr/http/httpclient_test.cc
+++ b/src/libaktualizr/http/httpclient_test.cc
@@ -8,6 +8,7 @@
 
 #include "json/json.h"
 
+#include <chrono>
 #include "http/httpclient.h"
 #include "libaktualizr/types.h"
 #include "test_utils.h"
@@ -19,14 +20,14 @@ TEST(CopyConstructorTest, copied) {
   HttpClient http;
   HttpClient http_copy(http);
   std::string path = "/path/1/2/3";
-  Json::Value resp = http_copy.get(server + path, HttpInterface::kNoLimit).getJson();
+  Json::Value resp = http_copy.get(server + path, HttpInterface::kNoLimit, nullptr).getJson();
   EXPECT_EQ(resp["path"].asString(), path);
 }
 
 TEST(GetTest, get_performed) {
   HttpClient http;
   std::string path = "/path/1/2/3";
-  Json::Value response = http.get(server + path, HttpInterface::kNoLimit).getJson();
+  Json::Value response = http.get(server + path, HttpInterface::kNoLimit, nullptr).getJson();
   EXPECT_EQ(response["path"].asString(), path);
 }
 
@@ -34,7 +35,7 @@ TEST(GetTestWithHeaders, get_performed) {
   std::vector<std::string> headers = {"Authorization: Bearer token"};
   HttpClient http(&headers);
   std::string path = "/auth_call";
-  Json::Value response = http.get(server + path, HttpInterface::kNoLimit).getJson();
+  Json::Value response = http.get(server + path, HttpInterface::kNoLimit, nullptr).getJson();
   EXPECT_EQ(response["status"].asString(), "good");
 }
 
@@ -42,7 +43,7 @@ TEST(GetTestWithHeaders, get_performed) {
 TEST(GetTest, download_size_limit) {
   HttpClient http;
   std::string path = "/large_file";
-  HttpResponse resp = http.get(server + path, 1024);
+  HttpResponse resp = http.get(server + path, 1024, nullptr);
   std::cout << "RESP SIZE " << resp.body.length() << std::endl;
   EXPECT_EQ(resp.curl_code, CURLE_FILESIZE_EXCEEDED);
 }
@@ -53,8 +54,32 @@ TEST(GetTest, download_speed_limit) {
   std::string path = "/slow_file";
 
   http.overrideSpeedLimitParams(3, 5000);
-  HttpResponse resp = http.get(server + path, HttpInterface::kNoLimit);
+  HttpResponse resp = http.get(server + path, HttpInterface::kNoLimit, nullptr);
   EXPECT_EQ(resp.curl_code, CURLE_OPERATION_TIMEDOUT);
+}
+
+TEST(GetTest, cancellation) {
+  HttpClient http;
+  std::string path = "/slow_file";
+  api::FlowControlToken token;
+  std::atomic<bool> did_abort;
+  auto end = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  std::thread t1([&token, end, &did_abort] {
+    std::this_thread::sleep_until(end);
+    token.setAbort();
+    did_abort = true;
+  });
+  HttpResponse resp = http.get(server + path, HttpInterface::kNoLimit, &token);
+  auto actual_end = std::chrono::steady_clock::now();
+  EXPECT_TRUE(did_abort);
+  auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(actual_end - end).count();
+
+  LOG_INFO << "Took:" << diff << "ms to abort";
+  // Curl takes ~2 seconds to call the progress meter and abort
+  EXPECT_LE(0, diff);
+  EXPECT_LE(diff, 3000);
+  EXPECT_EQ(resp.curl_code, CURLE_ABORTED_BY_CALLBACK);
+  t1.join();
 }
 
 TEST(PostTest, post_performed) {
@@ -85,7 +110,7 @@ TEST(HttpClient, user_agent) {
     // test the default, when setUserAgent hasn't been called yet
     HttpClient http;
 
-    const auto resp = http.get(server + "/user_agent", HttpInterface::kNoLimit);
+    const auto resp = http.get(server + "/user_agent", HttpInterface::kNoLimit, nullptr);
     const auto app = resp.body.substr(0, resp.body.find('/'));
     EXPECT_EQ(app, "Aktualizr");
   }
@@ -95,7 +120,7 @@ TEST(HttpClient, user_agent) {
   {
     HttpClient http;
 
-    auto resp = http.get(server + "/user_agent", HttpInterface::kNoLimit);
+    auto resp = http.get(server + "/user_agent", HttpInterface::kNoLimit, nullptr);
     EXPECT_EQ(resp.body, "blah");
   }
 }
@@ -107,11 +132,11 @@ TEST(Headers, update_header) {
   ASSERT_FALSE(http.updateHeader("NOSUCHHEADER", "foo"));
 
   std::string path = "/auth_call";
-  std::string body = http.get(server + path, HttpInterface::kNoLimit).body;
+  std::string body = http.get(server + path, HttpInterface::kNoLimit, nullptr).body;
   EXPECT_EQ(body, "{}");
 
   ASSERT_TRUE(http.updateHeader("Authorization", "Bearer token"));
-  Json::Value response = http.get(server + path, HttpInterface::kNoLimit).getJson();
+  Json::Value response = http.get(server + path, HttpInterface::kNoLimit, nullptr).getJson();
   EXPECT_EQ(response["status"].asString(), "good");
 }
 

--- a/src/libaktualizr/http/httpinterface.h
+++ b/src/libaktualizr/http/httpinterface.h
@@ -10,6 +10,7 @@
 
 #include "libaktualizr/types.h"
 #include "logging/logging.h"
+#include "utilities/flow_control.h"
 #include "utilities/utils.h"
 
 using CurlHandler = std::shared_ptr<CURL>;
@@ -39,7 +40,8 @@ class HttpInterface {
  public:
   HttpInterface() = default;
   virtual ~HttpInterface() = default;
-  virtual HttpResponse get(const std::string &url, int64_t maxsize) = 0;
+  virtual HttpResponse get(const std::string &url, int64_t maxsize, const api::FlowControlToken *flow_control) = 0;
+  HttpResponse get(const std::string &url, int64_t maxsize) { return get(url, maxsize, nullptr); }
   virtual HttpResponse post(const std::string &url, const std::string &content_type, const std::string &data) = 0;
   virtual HttpResponse post(const std::string &url, const Json::Value &data) = 0;
   virtual HttpResponse put(const std::string &url, const std::string &content_type, const std::string &data) = 0;

--- a/src/libaktualizr/primary/aktualizr.cc
+++ b/src/libaktualizr/primary/aktualizr.cc
@@ -26,7 +26,7 @@ Aktualizr::Aktualizr(Config config, std::shared_ptr<INvStorage> storage_in,
   storage_ = move(storage_in);
   storage_->importData(config_.import);
 
-  uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, http_in, sig_);
+  uptane_client_ = std::make_shared<SotaUptaneClient>(config_, storage_, http_in, sig_, api_queue_->FlowControlToken());
 }
 
 Aktualizr::~Aktualizr() { api_queue_.reset(nullptr); }
@@ -161,8 +161,7 @@ std::future<result::UpdateCheck> Aktualizr::CheckUpdates() {
 }
 
 std::future<result::Download> Aktualizr::Download(const std::vector<Uptane::Target> &updates) {
-  std::function<result::Download(const api::FlowControlToken *)> task(
-      [this, updates](const api::FlowControlToken *token) { return uptane_client_->downloadImages(updates, token); });
+  std::function<result::Download()> task([this, updates]() { return uptane_client_->downloadImages(updates); });
   return api_queue_->enqueue(move(task));
 }
 

--- a/src/libaktualizr/primary/aktualizr_lite_test.cc
+++ b/src/libaktualizr/primary/aktualizr_lite_test.cc
@@ -146,7 +146,7 @@ class AkliteMock {
 
  public:
   data::InstallationResult update() {
-    image_repo_.updateMeta(*storage_, *fetcher_);
+    image_repo_.updateMeta(*storage_, *fetcher_, nullptr);
     image_repo_.checkMetaOffline(*storage_);
 
     std::shared_ptr<const Uptane::Targets> targets = image_repo_.getTargets();

--- a/src/libaktualizr/primary/aktualizr_test.cc
+++ b/src/libaktualizr/primary/aktualizr_test.cc
@@ -1945,14 +1945,14 @@ class HttpFakeCampaign : public HttpFake {
   HttpFakeCampaign(const boost::filesystem::path& test_dir_in, const boost::filesystem::path& meta_dir_in)
       : HttpFake(test_dir_in, "", meta_dir_in) {}
 
-  HttpResponse get(const std::string& url, int64_t maxsize) override {
+  HttpResponse get(const std::string& url, int64_t maxsize, const api::FlowControlToken* flow_control) override {
     EXPECT_NE(url.find("campaigner/"), std::string::npos);
     boost::filesystem::path path = meta_dir / url.substr(tls_server.size() + strlen("campaigner/"));
 
     if (url.find("campaigner/campaigns") != std::string::npos) {
       return HttpResponse(Utils::readFile(path.parent_path() / "campaigner/campaigns.json"), 200, CURLE_OK, "");
     }
-    return HttpFake::get(url, maxsize);
+    return HttpFake::get(url, maxsize, flow_control);
   }
 
   HttpResponse handle_event(const std::string& url, const Json::Value& data) override {

--- a/src/libaktualizr/primary/metadata_fetch_test.cc
+++ b/src/libaktualizr/primary/metadata_fetch_test.cc
@@ -13,7 +13,7 @@ class HttpFakeMetaCounter : public HttpFake {
   HttpFakeMetaCounter(const boost::filesystem::path &test_dir_in, const boost::filesystem::path &meta_dir_in)
       : HttpFake(test_dir_in, "", meta_dir_in) {}
 
-  HttpResponse get(const std::string &url, int64_t maxsize) override {
+  HttpResponse get(const std::string &url, int64_t maxsize, const api::FlowControlToken *flow_control) override {
     if (url.find("director/1.root.json") != std::string::npos) {
       ++director_1root_count;
     }
@@ -39,7 +39,7 @@ class HttpFakeMetaCounter : public HttpFake {
       ++image_targets_count;
     }
 
-    return HttpFake::get(url, maxsize);
+    return HttpFake::get(url, maxsize, flow_control);
   }
 
   int director_1root_count{0};

--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -62,6 +62,11 @@ add_aktualizr_test(NAME uptane_serial SOURCES uptane_serial_test.cc
                    PROJECT_WORKING_DIRECTORY
                    LIBRARIES uptane_generator_lib virtual_secondary)
 
+add_aktualizr_test(NAME uptane_cancellation SOURCES uptane_cancellation_test.cc
+                   PROJECT_WORKING_DIRECTORY
+                   LIBRARIES uptane_generator_lib virtual_secondary)
+
+
 if(BUILD_OSTREE)
     # Test that SotaUptaneClient::AssembleManifest() works correctly under OSTree.
     # This requires the OSTree sysroot created by make_ostree_sysroot in

--- a/src/libaktualizr/uptane/directorrepository.cc
+++ b/src/libaktualizr/uptane/directorrepository.cc
@@ -93,7 +93,8 @@ void DirectorRepository::checkMetaOffline(INvStorage& storage) {
   }
 }
 
-void DirectorRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher) {
+void DirectorRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher,
+                                    const api::FlowControlToken* flow_control) {
   // Uptane step 2 (download time) is not implemented yet.
   // Uptane step 3 (download metadata)
 
@@ -110,7 +111,8 @@ void DirectorRepository::updateMeta(INvStorage& storage, const IMetadataFetcher&
   {
     std::string director_targets;
 
-    fetcher.fetchLatestRole(&director_targets, kMaxDirectorTargetsSize, RepositoryType::Director(), Role::Targets());
+    fetcher.fetchLatestRole(&director_targets, kMaxDirectorTargetsSize, RepositoryType::Director(), Role::Targets(),
+                            flow_control);
     int remote_version = extractVersionUntrusted(director_targets);
 
     int local_version;

--- a/src/libaktualizr/uptane/directorrepository.h
+++ b/src/libaktualizr/uptane/directorrepository.h
@@ -24,7 +24,8 @@ class DirectorRepository : public RepositoryCommon {
   void checkMetaOffline(INvStorage& storage);
   void dropTargets(INvStorage& storage);
 
-  void updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher) override;
+  void updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher,
+                  const api::FlowControlToken* flow_control) override;
   bool matchTargetsWithImageTargets(const std::shared_ptr<const Uptane::Targets>& image_targets) const;
 
  private:

--- a/src/libaktualizr/uptane/exceptions.h
+++ b/src/libaktualizr/uptane/exceptions.h
@@ -134,6 +134,11 @@ class InvalidTarget : public Exception {
       : Exception(reponame, "The target had a non-OSTree package that can not be installed on an OSTree system.") {}
 };
 
+class LocallyAborted : public Exception {
+ public:
+  explicit LocallyAborted(const std::string& reponame) : Exception(reponame, "Update was aborted on the client") {}
+};
+
 }  // namespace Uptane
 
 #endif

--- a/src/libaktualizr/uptane/fetcher.cc
+++ b/src/libaktualizr/uptane/fetcher.cc
@@ -5,13 +5,16 @@
 namespace Uptane {
 
 void Fetcher::fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Uptane::Role& role,
-                        Version version) const {
+                        Version version, const api::FlowControlToken* flow_control) const {
   std::string url = (repo == RepositoryType::Director()) ? director_server : repo_server;
   if (role.IsDelegation()) {
     url += "/delegations";
   }
   url += "/" + version.RoleFileName(role);
-  HttpResponse response = http->get(url, maxsize);
+  HttpResponse response = http->get(url, maxsize, flow_control);
+  if (flow_control != nullptr && flow_control->hasAborted()) {
+    throw Uptane::LocallyAborted(repo);
+  }
   if (!response.isOk()) {
     throw Uptane::MetadataFetchFailure(repo.ToString(), role.ToString());
   }

--- a/src/libaktualizr/uptane/fetcher.h
+++ b/src/libaktualizr/uptane/fetcher.h
@@ -4,6 +4,7 @@
 #include "http/httpinterface.h"
 #include "libaktualizr/config.h"
 #include "tuf.h"
+#include "utilities/flow_control.h"
 
 namespace Uptane {
 
@@ -20,10 +21,31 @@ class IMetadataFetcher {
   IMetadataFetcher& operator=(IMetadataFetcher&&) = delete;
   virtual ~IMetadataFetcher() = default;
 
+  /**
+   * Fetch a role at a version (which might be 'latest').
+   *
+   * If the fetch fails, throw something derived Uptane::Exception
+   * @param result
+   * @param maxsize
+   * @param repo
+   * @param role
+   * @param version
+   * @param flow_control
+   * @throws Uptane::MetadataFetchFailure If fetching metadata fails (e.g. network error)
+   * @throws Uptane::LocallyAborted If the caller aborts with flow_control->hasAborted()
+   */
   virtual void fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Uptane::Role& role,
-                         Version version) const = 0;
-  virtual void fetchLatestRole(std::string* result, int64_t maxsize, RepositoryType repo,
-                               const Uptane::Role& role) const = 0;
+                         Version version, const api::FlowControlToken* flow_control) const = 0;
+
+  void fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Uptane::Role& role,
+                 Version version) const {
+    return fetchRole(result, maxsize, repo, role, version, nullptr);
+  }
+
+  void fetchLatestRole(std::string* result, int64_t maxsize, RepositoryType repo, const Uptane::Role& role,
+                       const api::FlowControlToken* flow_control = nullptr) const {
+    fetchRole(result, maxsize, repo, role, Version(), flow_control);
+  }
 
  protected:
   IMetadataFetcher() = default;
@@ -38,12 +60,8 @@ class Fetcher : public IMetadataFetcher {
       : http(std::move(http_in)),
         repo_server(std::move(repo_server_in)),
         director_server(std::move(director_server_in)) {}
-  void fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Uptane::Role& role,
-                 Version version) const override;
-  void fetchLatestRole(std::string* result, int64_t maxsize, RepositoryType repo,
-                       const Uptane::Role& role) const override {
-    fetchRole(result, maxsize, repo, role, Version());
-  }
+  void fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Uptane::Role& role, Version version,
+                 const api::FlowControlToken* flow_control) const override;
 
   std::string getRepoServer() const { return repo_server; }
 

--- a/src/libaktualizr/uptane/imagerepository.cc
+++ b/src/libaktualizr/uptane/imagerepository.cc
@@ -32,10 +32,11 @@ void ImageRepository::checkTimestampExpired() {
   }
 }
 
-void ImageRepository::fetchSnapshot(INvStorage& storage, const IMetadataFetcher& fetcher, const int local_version) {
+void ImageRepository::fetchSnapshot(INvStorage& storage, const IMetadataFetcher& fetcher, const int local_version,
+                                    const api::FlowControlToken* flow_control) {
   std::string image_snapshot;
   const int64_t snapshot_size = (snapshotSize() > 0) ? snapshotSize() : kMaxSnapshotSize;
-  fetcher.fetchLatestRole(&image_snapshot, snapshot_size, RepositoryType::Image(), Role::Snapshot());
+  fetcher.fetchLatestRole(&image_snapshot, snapshot_size, RepositoryType::Image(), Role::Snapshot(), flow_control);
   const int remote_version = extractVersionUntrusted(image_snapshot);
 
   // 6. Check that each Targets metadata filename listed in the previous Snapshot metadata file is also listed in this
@@ -105,7 +106,8 @@ void ImageRepository::checkSnapshotExpired() {
   }
 }
 
-void ImageRepository::fetchTargets(INvStorage& storage, const IMetadataFetcher& fetcher, const int local_version) {
+void ImageRepository::fetchTargets(INvStorage& storage, const IMetadataFetcher& fetcher, const int local_version,
+                                   const api::FlowControlToken* flow_control) {
   std::string image_targets;
   const Role targets_role = Role::Targets();
 
@@ -114,7 +116,7 @@ void ImageRepository::fetchTargets(INvStorage& storage, const IMetadataFetcher& 
     targets_size = kMaxImageTargetsSize;
   }
 
-  fetcher.fetchLatestRole(&image_targets, targets_size, RepositoryType::Image(), targets_role);
+  fetcher.fetchLatestRole(&image_targets, targets_size, RepositoryType::Image(), targets_role, flow_control);
 
   const int remote_version = extractVersionUntrusted(image_targets);
 
@@ -212,7 +214,8 @@ void ImageRepository::checkTargetsExpired() {
   }
 }
 
-void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher) {
+void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher,
+                                 const api::FlowControlToken* flow_control) {
   resetMeta();
 
   updateRoot(storage, fetcher, RepositoryType::Image());
@@ -270,7 +273,7 @@ void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fe
 
     // If we don't, attempt to fetch the latest.
     if (fetch_snapshot) {
-      fetchSnapshot(storage, fetcher, local_version);
+      fetchSnapshot(storage, fetcher, local_version, flow_control);
     }
 
     checkSnapshotExpired();
@@ -299,7 +302,7 @@ void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fe
 
     // If we don't, attempt to fetch the latest.
     if (fetch_targets) {
-      fetchTargets(storage, fetcher, local_version);
+      fetchTargets(storage, fetcher, local_version, flow_control);
     }
 
     checkTargetsExpired();

--- a/src/libaktualizr/uptane/imagerepository.h
+++ b/src/libaktualizr/uptane/imagerepository.h
@@ -31,14 +31,17 @@ class ImageRepository : public RepositoryCommon {
   int64_t getRoleSize(const Uptane::Role& role) const;
 
   void checkMetaOffline(INvStorage& storage);
-  void updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher) override;
+  void updateMeta(INvStorage& storage, const IMetadataFetcher& fetcher,
+                  const api::FlowControlToken* flow_control) override;
 
  private:
   void checkTimestampExpired();
   void checkSnapshotExpired();
   int64_t snapshotSize() const { return timestamp.snapshot_size(); }
-  void fetchSnapshot(INvStorage& storage, const IMetadataFetcher& fetcher, int local_version);
-  void fetchTargets(INvStorage& storage, const IMetadataFetcher& fetcher, int local_version);
+  void fetchSnapshot(INvStorage& storage, const IMetadataFetcher& fetcher, int local_version,
+                     const api::FlowControlToken* flow_control);
+  void fetchTargets(INvStorage& storage, const IMetadataFetcher& fetcher, int local_version,
+                    const api::FlowControlToken* flow_control);
   void checkTargetsExpired();
 
   std::shared_ptr<Uptane::Targets> targets;

--- a/src/libaktualizr/uptane/iterator.cc
+++ b/src/libaktualizr/uptane/iterator.cc
@@ -6,8 +6,8 @@
 namespace Uptane {
 
 Targets getTrustedDelegation(const Role &delegate_role, const Targets &parent_targets,
-                             const ImageRepository &image_repo, INvStorage &storage, Fetcher &fetcher,
-                             const bool offline) {
+                             const ImageRepository &image_repo, INvStorage &storage, IMetadataFetcher &fetcher,
+                             const bool offline, const api::FlowControlToken *flow_control) {
   std::string delegation_meta;
   auto version_in_snapshot = image_repo.getRoleVersion(delegate_role);
 
@@ -29,7 +29,8 @@ Targets getTrustedDelegation(const Role &delegate_role, const Targets &parent_ta
       throw Uptane::DelegationMissing(delegate_role.ToString());
     }
     try {
-      fetcher.fetchLatestRole(&delegation_meta, Uptane::kMaxImageTargetsSize, RepositoryType::Image(), delegate_role);
+      fetcher.fetchLatestRole(&delegation_meta, Uptane::kMaxImageTargetsSize, RepositoryType::Image(), delegate_role,
+                              flow_control);
     } catch (const std::exception &e) {
       LOG_ERROR << "Fetch role error: " << e.what();
       throw Uptane::DelegationMissing(delegate_role.ToString());
@@ -60,8 +61,13 @@ Targets getTrustedDelegation(const Role &delegate_role, const Targets &parent_ta
 
 LazyTargetsList::DelegationIterator::DelegationIterator(const ImageRepository &repo,
                                                         std::shared_ptr<INvStorage> storage,
-                                                        std::shared_ptr<Fetcher> fetcher, bool is_end)
-    : repo_{repo}, storage_{std::move(storage)}, fetcher_{std::move(fetcher)}, is_end_{is_end} {
+                                                        std::shared_ptr<Fetcher> fetcher,
+                                                        const api::FlowControlToken *flow_control, bool is_end)
+    : repo_{repo},
+      storage_{std::move(storage)},
+      fetcher_{std::move(fetcher)},
+      flow_control_{flow_control},
+      is_end_{is_end} {
   tree_ = std::make_shared<DelegatedTargetTreeNode>();
   tree_node_ = tree_.get();
 
@@ -90,10 +96,10 @@ void LazyTargetsList::DelegationIterator::renewTargetsData() {
 
       auto fetched_role = Role(parent_targets->delegated_role_names_[idx], true);
       parent_targets = std::make_shared<const Targets>(
-          getTrustedDelegation(fetched_role, *parent_targets, repo_, *storage_, *fetcher_, false));
+          getTrustedDelegation(fetched_role, *parent_targets, repo_, *storage_, *fetcher_, false, flow_control_));
     }
-    cur_targets_ =
-        std::make_shared<Targets>(getTrustedDelegation(role, *parent_targets, repo_, *storage_, *fetcher_, false));
+    cur_targets_ = std::make_shared<Targets>(
+        getTrustedDelegation(role, *parent_targets, repo_, *storage_, *fetcher_, false, flow_control_));
   }
 }
 

--- a/src/libaktualizr/uptane/iterator.h
+++ b/src/libaktualizr/uptane/iterator.h
@@ -3,11 +3,13 @@
 
 #include "fetcher.h"
 #include "imagerepository.h"
+#include "utilities/flow_control.h"
 
 namespace Uptane {
 
 Targets getTrustedDelegation(const Role &delegate_role, const Targets &parent_targets,
-                             const ImageRepository &image_repo, INvStorage &storage, Fetcher &fetcher, bool offline);
+                             const ImageRepository &image_repo, INvStorage &storage, IMetadataFetcher &fetcher,
+                             bool offline, const api::FlowControlToken *flow_control);
 
 class LazyTargetsList {
  public:
@@ -27,38 +29,41 @@ class LazyTargetsList {
 
    public:
     explicit DelegationIterator(const ImageRepository &repo, std::shared_ptr<INvStorage> storage,
-                                std::shared_ptr<Uptane::Fetcher> fetcher, bool is_end = false);
+                                std::shared_ptr<Uptane::Fetcher> fetcher, const api::FlowControlToken *flow_control,
+                                bool is_end = false);
     DelegationIterator operator++();
     bool operator==(const DelegationIterator &other) const;
     bool operator!=(const DelegationIterator &other) const { return !(*this == other); }
     const Uptane::Target &operator*();
 
    private:
+    void renewTargetsData();
+
     std::shared_ptr<DelegatedTargetTreeNode> tree_;
     DelegatedTargetTreeNode *tree_node_;
     const ImageRepository &repo_;
     std::shared_ptr<INvStorage> storage_;
     std::shared_ptr<Fetcher> fetcher_;
+    const api::FlowControlToken *flow_control_;
     std::shared_ptr<const Targets> cur_targets_;
     std::vector<Targets>::size_type target_idx_{0};
     std::vector<std::shared_ptr<DelegatedTargetTreeNode>>::size_type children_idx_{0};
     bool terminating_{false};
     int level_{0};
     bool is_end_;
-
-    void renewTargetsData();
   };
 
   explicit LazyTargetsList(const ImageRepository &repo, std::shared_ptr<INvStorage> storage,
-                           std::shared_ptr<Fetcher> fetcher)
-      : repo_{repo}, storage_{std::move(storage)}, fetcher_{std::move(fetcher)} {}
-  DelegationIterator begin() { return DelegationIterator(repo_, storage_, fetcher_); }
-  DelegationIterator end() { return DelegationIterator(repo_, storage_, fetcher_, true); }
+                           std::shared_ptr<Fetcher> fetcher, const api::FlowControlToken *flow_control)
+      : repo_{repo}, storage_{std::move(storage)}, fetcher_{std::move(fetcher)}, flow_control_{flow_control} {}
+  DelegationIterator begin() { return DelegationIterator(repo_, storage_, fetcher_, flow_control_); }
+  DelegationIterator end() { return DelegationIterator(repo_, storage_, fetcher_, flow_control_, true); }
 
  private:
   const ImageRepository &repo_;
   std::shared_ptr<INvStorage> storage_;
   std::shared_ptr<Uptane::Fetcher> fetcher_;
+  const api::FlowControlToken *flow_control_;
 };
 }  // namespace Uptane
 

--- a/src/libaktualizr/uptane/secondary_metadata.cc
+++ b/src/libaktualizr/uptane/secondary_metadata.cc
@@ -18,15 +18,10 @@ SecondaryMetadata::SecondaryMetadata(MetaBundle meta_bundle_in) : meta_bundle_(s
 }
 
 void SecondaryMetadata::fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Role& role,
-                                  Version version) const {
+                                  Version version, const api::FlowControlToken* flow_control) const {
   (void)maxsize;
+  (void)flow_control;  // Safe, we are working locally here
   getRoleMetadata(result, repo, role, version);
-}
-
-void SecondaryMetadata::fetchLatestRole(std::string* result, int64_t maxsize, RepositoryType repo,
-                                        const Role& role) const {
-  (void)maxsize;
-  getRoleMetadata(result, repo, role, Version());
 }
 
 void SecondaryMetadata::getRoleMetadata(std::string* result, const RepositoryType& repo, const Role& role,

--- a/src/libaktualizr/uptane/secondary_metadata.h
+++ b/src/libaktualizr/uptane/secondary_metadata.h
@@ -10,9 +10,8 @@ class SecondaryMetadata : public IMetadataFetcher {
  public:
   explicit SecondaryMetadata(MetaBundle meta_bundle_in);
 
-  void fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Role& role,
-                 Version version) const override;
-  void fetchLatestRole(std::string* result, int64_t maxsize, RepositoryType repo, const Role& role) const override;
+  void fetchRole(std::string* result, int64_t maxsize, RepositoryType repo, const Role& role, Version version,
+                 const api::FlowControlToken* flow_control) const override;
 
  protected:
   virtual void getRoleMetadata(std::string* result, const RepositoryType& repo, const Role& role,

--- a/src/libaktualizr/uptane/uptane_cancellation_test.cc
+++ b/src/libaktualizr/uptane/uptane_cancellation_test.cc
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include "httpfake.h"
+#include "libaktualizr/config.h"
+#include "storage/invstorage.h"
+#include "uptane_test_common.h"
+#include "utilities/utils.h"
+
+TEST(UptaneCancellation, Simple) {
+  Config conf("tests/config/basic.toml");
+  TemporaryDirectory temp_dir;
+  auto http = std::make_shared<HttpFake>(temp_dir.Path(), "hasupdates");
+  conf.uptane.director_server = http->tls_server + "director";
+  conf.uptane.repo_server = http->tls_server + "repo";
+  conf.pacman.type = PACKAGE_MANAGER_NONE;
+  conf.pacman.images_path = temp_dir.Path() / "images";
+  conf.provision.primary_ecu_serial = "CA:FE:A6:D2:84:9D";
+  conf.provision.primary_ecu_hardware_id = "primary_hw";
+  conf.storage.path = temp_dir.Path();
+  conf.tls.server = http->tls_server;
+  UptaneTestCommon::addDefaultSecondary(conf, temp_dir, "secondary_ecu_serial", "secondary_hw");
+
+  conf.postUpdateValues();
+
+  auto storage = INvStorage::newStorage(conf.storage);
+  auto events_channel = std::make_shared<event::Channel>();
+  auto dut = std_::make_unique<UptaneTestCommon::TestUptaneClient>(conf, storage, http, events_channel);
+  EXPECT_NO_THROW(dut->initialize());
+
+  // Given the flow control is cancelled...
+  auto flow_control = dut->FlowControlToken();
+  flow_control->setAbort();
+
+  // ...checking for updates should abort
+  auto result = dut->fetchMeta();
+  EXPECT_EQ(result.status, result::UpdateStatus::kError);
+
+  // But trying again (with flow control reset) succeeds
+  flow_control->reset();
+
+  auto result2 = dut->fetchMeta();
+  EXPECT_EQ(result2.status, result::UpdateStatus::kUpdatesAvailable);
+}
+
+#ifndef __NO_MAIN__
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  logger_init();
+  logger_set_threshold(boost::log::trivial::trace);
+
+  return RUN_ALL_TESTS();
+}
+#endif

--- a/src/libaktualizr/uptane/uptane_network_test.cc
+++ b/src/libaktualizr/uptane/uptane_network_test.cc
@@ -140,11 +140,11 @@ TEST(UptaneNetwork, DownloadFailure) {
 class HttpUnstable : public HttpFake {
  public:
   explicit HttpUnstable(const boost::filesystem::path &test_dir_in) : HttpFake(test_dir_in, "hasupdates") {}
-  HttpResponse get(const std::string &url, int64_t maxsize) override {
+  HttpResponse get(const std::string &url, int64_t maxsize, const api::FlowControlToken *flow_control) override {
     if (!connectSwitch) {
       return HttpResponse({}, 503, CURLE_OK, "");
     } else {
-      return HttpFake::get(url, maxsize);
+      return HttpFake::get(url, maxsize, flow_control);
     }
   }
 

--- a/src/libaktualizr/uptane/uptanerepository.h
+++ b/src/libaktualizr/uptane/uptanerepository.h
@@ -1,10 +1,12 @@
 #ifndef UPTANE_REPOSITORY_H_
 #define UPTANE_REPOSITORY_H_
 
-#include <cstdint>               // for int64_t
-#include <string>                // for string
+#include <cstdint>  // for int64_t
+#include <string>   // for string
+#include "fetcher.h"
 #include "libaktualizr/types.h"  // for TimeStamp
 #include "uptane/tuf.h"          // for Root, RepositoryType
+#include "utilities/flow_control.h"
 
 class INvStorage;
 
@@ -24,7 +26,8 @@ class RepositoryCommon {
   void verifyRoot(const std::string &root_raw);
   int rootVersion() const { return root.version(); }
   bool rootExpired() const { return root.isExpired(TimeStamp::Now()); }
-  virtual void updateMeta(INvStorage &storage, const IMetadataFetcher &fetcher) = 0;
+  virtual void updateMeta(INvStorage &storage, const IMetadataFetcher &fetcher,
+                          const api::FlowControlToken *flow_control) = 0;
 
  protected:
   void resetRoot();

--- a/src/libaktualizr/utilities/CMakeLists.txt
+++ b/src/libaktualizr/utilities/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES aktualizr_version.cc
             apiqueue.cc
             dequeue_buffer.cc
+            flow_control.cc
             results.cc
             sig_handler.cc
             timer.cc
@@ -13,6 +14,7 @@ set(HEADERS apiqueue.h
             dequeue_buffer.h
             exceptions.h
             fault_injection.h
+            flow_control.h
             sig_handler.h
             timer.h
             utils.h

--- a/src/libaktualizr/utilities/apiqueue.cc
+++ b/src/libaktualizr/utilities/apiqueue.cc
@@ -3,46 +3,6 @@
 
 namespace api {
 
-bool FlowControlToken::setPause(bool set_paused) {
-  {
-    std::lock_guard<std::mutex> lock(m_);
-    if (set_paused && state_ == State::kRunning) {
-      state_ = State::kPaused;
-    } else if (!set_paused && state_ == State::kPaused) {
-      state_ = State::kRunning;
-    } else {
-      return false;
-    }
-  }
-  cv_.notify_all();
-  return true;
-}
-
-bool FlowControlToken::setAbort() {
-  {
-    std::lock_guard<std::mutex> g(m_);
-    if (state_ == State::kAborted) {
-      return false;
-    }
-    state_ = State::kAborted;
-  }
-  cv_.notify_all();
-  return true;
-}
-
-bool FlowControlToken::canContinue(bool blocking) const {
-  std::unique_lock<std::mutex> lk(m_);
-  if (blocking) {
-    cv_.wait(lk, [this] { return state_ != State::kPaused; });
-  }
-  return state_ == State::kRunning;
-}
-
-void FlowControlToken::reset() {
-  std::lock_guard<std::mutex> g(m_);
-  state_ = State::kRunning;
-}
-
 CommandQueue::~CommandQueue() {
   try {
     abort(false);

--- a/src/libaktualizr/utilities/apiqueue.h
+++ b/src/libaktualizr/utilities/apiqueue.h
@@ -10,49 +10,9 @@
 #include <thread>
 #include <utility>
 
+#include "utilities/flow_control.h"
+
 namespace api {
-
-///
-/// Provides a thread-safe way to pause and terminate task execution.
-/// A task must call canContinue() method to check the current state.
-///
-class FlowControlToken {
- public:
-  ///
-  /// Called by the controlling thread to request the task to pause or resume.
-  /// Has no effect if the task was aborted.
-  /// @return `true` if the state was changed, `false` otherwise.
-  ///
-  bool setPause(bool set_paused);
-
-  ///
-  /// Called by the controlling thread to request the task to abort.
-  /// @return `false` if the task was already aborted, `true` otherwise.
-  ///
-  bool setAbort();
-
-  ///
-  /// Called by the controlled thread to query the currently requested state.
-  /// Sleeps if the state is `Paused` and `blocking == true`.
-  /// @return `true` for `Running` state, `false` for `Aborted`,
-  /// and also `false` for the `Paused` state, if the call is non-blocking.
-  ///
-  bool canContinue(bool blocking = true) const;
-
-  ////
-  //// Sets token to the initial state
-  ////
-  void reset();
-
- private:
-  enum class State {
-    kRunning,  // transitions: ->Paused, ->Aborted
-    kPaused,   // transitions: ->Running, ->Aborted
-    kAborted   // transitions: none
-  } state_{State::kRunning};
-  mutable std::mutex m_;
-  mutable std::condition_variable cv_;
-};
 
 struct Context {
   api::FlowControlToken* flow_control;
@@ -147,7 +107,14 @@ class CommandQueue {
   CommandQueue& operator=(CommandQueue&&) = delete;
   void run();
   bool pause(bool do_pause);  // returns true iff pause→resume or resume→pause
+  /**
+   * Stop any current operation and flush the queue.
+   * Any in-progress operation will have finished before this call returns.
+   * @param restart_thread
+   */
   void abort(bool restart_thread = true);
+
+  const api::FlowControlToken* FlowControlToken() const { return &token_; }
 
   template <class R>
   std::future<R> enqueue(std::function<R()>&& function) {
@@ -175,7 +142,7 @@ class CommandQueue {
   std::queue<ICommand::Ptr> queue_;
   std::mutex m_;
   std::condition_variable cv_;
-  FlowControlToken token_;
+  class api::FlowControlToken token_;
 };
 
 }  // namespace api

--- a/src/libaktualizr/utilities/flow_control.cc
+++ b/src/libaktualizr/utilities/flow_control.cc
@@ -1,0 +1,59 @@
+#include "utilities/flow_control.h"
+
+#include <cassert>
+
+namespace api {
+
+bool FlowControlToken::IsValid() const { return sentinel_ == SENTINEL; }
+
+bool FlowControlToken::setPause(bool set_paused) {
+  assert(IsValid());
+  {
+    std::lock_guard<std::mutex> lock(m_);
+    if (set_paused && state_ == State::kRunning) {
+      state_ = State::kPaused;
+    } else if (!set_paused && state_ == State::kPaused) {
+      state_ = State::kRunning;
+    } else {
+      return false;
+    }
+  }
+  cv_.notify_all();
+  return true;
+}
+
+bool FlowControlToken::setAbort() {
+  assert(IsValid());
+
+  {
+    std::lock_guard<std::mutex> g(m_);
+    if (state_ == State::kAborted) {
+      return false;
+    }
+    state_ = State::kAborted;
+  }
+  cv_.notify_all();
+  return true;
+}
+
+bool FlowControlToken::canContinue(bool blocking) const {
+  assert(IsValid());
+  std::unique_lock<std::mutex> lk(m_);
+  if (blocking) {
+    cv_.wait(lk, [this] { return state_ != State::kPaused; });
+  }
+  return state_ == State::kRunning;
+}
+
+bool FlowControlToken::hasAborted() const {
+  assert(IsValid());
+  return !canContinue(false);
+}
+
+void FlowControlToken::reset() {
+  assert(IsValid());
+
+  std::lock_guard<std::mutex> g(m_);
+  state_ = State::kRunning;
+}
+}  // namespace api

--- a/src/libaktualizr/utilities/flow_control.h
+++ b/src/libaktualizr/utilities/flow_control.h
@@ -1,0 +1,71 @@
+#ifndef AKTUALIZR_FLOW_CONTROL_H
+#define AKTUALIZR_FLOW_CONTROL_H
+
+#include <condition_variable>
+#include <mutex>
+
+namespace api {
+
+///
+/// Provides a thread-safe way to pause and terminate task execution.
+/// A task must call canContinue() method to check the current state.
+///
+class FlowControlToken {
+ public:
+  FlowControlToken() = default;
+  ~FlowControlToken() = default;
+
+  // Non-copyable, non,moveable
+  FlowControlToken(const FlowControlToken&) = delete;
+  FlowControlToken& operator=(const FlowControlToken&) = delete;
+  FlowControlToken(FlowControlToken&&) = delete;
+  FlowControlToken& operator=(FlowControlToken&&) = delete;
+
+  /// After casting from a void pointer check this is true before continuing
+  /// \return `true` if this really does point to a FlowControlToken
+  bool IsValid() const;
+
+  ///
+  /// Called by the controlling thread to request the task to pause or resume.
+  /// Has no effect if the task was aborted.
+  /// @return `true` if the state was changed, `false` otherwise.
+  ///
+  bool setPause(bool set_paused);
+
+  ///
+  /// Called by the controlling thread to request the task to abort.
+  /// @return `false` if the task was already aborted, `true` otherwise.
+  ///
+  bool setAbort();
+
+  ///
+  /// Called by the controlled thread to query the currently requested state.
+  /// Sleeps if the state is `Paused` and `blocking == true`.
+  /// @return `true` for `Running` state, `false` for `Aborted`,
+  /// and also `false` for the `Paused` state, if the call is non-blocking.
+  ///
+  bool canContinue(bool blocking = true) const;
+
+  ///
+  /// \return true if the operation has aborted and we should stop trying to make progress and start aborting
+  bool hasAborted() const;
+
+  ////
+  //// Sets token to the initial state
+  ////
+  void reset();
+
+ private:
+  static const uint32_t SENTINEL = 0xced53470;
+  const uint32_t sentinel_{SENTINEL};
+  enum class State {
+    kRunning,  // transitions: ->Paused, ->Aborted
+    kPaused,   // transitions: ->Running, ->Aborted
+    kAborted   // transitions: none
+  } state_{State::kRunning};
+  mutable std::mutex m_;
+  mutable std::condition_variable cv_;
+};
+
+}  // namespace api
+#endif  // AKTUALIZR_FLOW_CONTROL_H

--- a/src/virtual_secondary/managedsecondary.h
+++ b/src/virtual_secondary/managedsecondary.h
@@ -65,8 +65,9 @@ class ManagedSecondary : public SecondaryInterface {
   int getRootVersion(bool director) const override;
   data::InstallationResult putRoot(const std::string& root, bool director) override;
 
-  data::InstallationResult sendFirmware(const Uptane::Target& target) override;
-  data::InstallationResult install(const Uptane::Target& target) override;
+  data::InstallationResult sendFirmware(const Uptane::Target& target,
+                                        const api::FlowControlToken* flow_control) override;
+  data::InstallationResult install(const Uptane::Target& target, const api::FlowControlToken* flow_control) override;
 
   Uptane::Manifest getManifest() const override;
 

--- a/src/virtual_secondary/virtualsecondary.cc
+++ b/src/virtual_secondary/virtualsecondary.cc
@@ -90,7 +90,8 @@ data::InstallationResult VirtualSecondary::putRoot(const std::string& root, bool
   return ManagedSecondary::putRoot(root, director);
 }
 
-data::InstallationResult VirtualSecondary::sendFirmware(const Uptane::Target& target) {
+data::InstallationResult VirtualSecondary::sendFirmware(const Uptane::Target& target,
+                                                        const api::FlowControlToken* flow_control) {
   if (fiu_fail((std::string("secondary_sendfirmware_") + getSerial().ToString()).c_str()) != 0) {
     // Put the injected failure string into the ResultCode so that it shows up
     // in the device's concatenated InstallationResult.
@@ -98,10 +99,11 @@ data::InstallationResult VirtualSecondary::sendFirmware(const Uptane::Target& ta
         data::ResultCode(data::ResultCode::Numeric::kDownloadFailed, fault_injection_last_info()), "Forced failure");
   }
 
-  return ManagedSecondary::sendFirmware(target);
+  return ManagedSecondary::sendFirmware(target, flow_control);
 }
 
-data::InstallationResult VirtualSecondary::install(const Uptane::Target& target) {
+data::InstallationResult VirtualSecondary::install(const Uptane::Target& target,
+                                                   const api::FlowControlToken* flow_control) {
   if (fiu_fail((std::string("secondary_install_") + getSerial().ToString()).c_str()) != 0) {
     // Put the injected failure string into the ResultCode so that it shows up
     // in the device's concatenated InstallationResult.
@@ -109,7 +111,7 @@ data::InstallationResult VirtualSecondary::install(const Uptane::Target& target)
         data::ResultCode(data::ResultCode::Numeric::kInstallFailed, fault_injection_last_info()), "Forced failure");
   }
 
-  return ManagedSecondary::install(target);
+  return ManagedSecondary::install(target, flow_control);
 }
 
 }  // namespace Primary

--- a/src/virtual_secondary/virtualsecondary.h
+++ b/src/virtual_secondary/virtualsecondary.h
@@ -26,8 +26,9 @@ class VirtualSecondary : public ManagedSecondary {
   std::string Type() const override { return VirtualSecondaryConfig::Type; }
   data::InstallationResult putMetadata(const Uptane::Target& target) override;
   data::InstallationResult putRoot(const std::string& root, bool director) override;
-  data::InstallationResult sendFirmware(const Uptane::Target& target) override;
-  data::InstallationResult install(const Uptane::Target& target) override;
+  data::InstallationResult sendFirmware(const Uptane::Target& target,
+                                        const api::FlowControlToken* flow_control) override;
+  data::InstallationResult install(const Uptane::Target& target, const api::FlowControlToken* flow_control) override;
 
   bool ping() const override { return true; }
 };

--- a/tests/httpfake.cc
+++ b/tests/httpfake.cc
@@ -37,9 +37,14 @@ bool HttpFake::rewrite(std::string &url, const std::string &pattern) const {
   return true;
 }
 
-HttpResponse HttpFake::get(const std::string &url, int64_t maxsize) {
-  (void)maxsize;
-  std::cout << "URL requested: " << url << "\n";
+HttpResponse HttpFake::get(const std::string &url, int64_t maxsize,
+                           const api::FlowControlToken *flow_control) {
+    (void)maxsize;
+    std::cout << "URL requested: " << url << "\n";
+
+    if (flow_control != nullptr && flow_control->hasAborted()) {
+      return HttpResponse("", 0, CURLE_ABORTED_BY_CALLBACK, "Canceled by FlowControlToken");
+    }
 
   std::string new_url = url;
   if (!flavor_.empty()) {

--- a/tests/httpfake.h
+++ b/tests/httpfake.h
@@ -37,7 +37,8 @@ class HttpFake : public HttpInterface {
     return HttpResponse("", 400, CURLE_OK, "");
   }
 
-  HttpResponse get(const std::string &url, int64_t maxsize) override;
+  using HttpInterface::get;
+  HttpResponse get(const std::string &url, int64_t maxsize, const api::FlowControlToken *flow_control) override;
 
   HttpResponse post(const std::string &url, const std::string &content_type, const std::string &data) override {
     (void)url;

--- a/tests/uptane_test_common.h
+++ b/tests/uptane_test_common.h
@@ -45,7 +45,7 @@ struct UptaneTestCommon {
                      std::shared_ptr<INvStorage> storage_in,
                      std::shared_ptr<HttpInterface> http_client,
                      std::shared_ptr<event::Channel> events_channel_in):
-      SotaUptaneClient(config_in, storage_in, http_client, events_channel_in) {
+      SotaUptaneClient(config_in, storage_in, http_client, events_channel_in, &flow_control_) {
 
       if (boost::filesystem::exists(config_in.uptane.secondary_config_file)) {
           for (const auto& item : Primary::VirtualSecondaryConfig::create_from_file(config_in.uptane.secondary_config_file)) {
@@ -60,6 +60,10 @@ struct UptaneTestCommon {
 
     TestUptaneClient(Config &config_in,
                      std::shared_ptr<INvStorage> storage_in) : TestUptaneClient(config_in, storage_in, std::make_shared<HttpClient>()) {}
+
+    api::FlowControlToken* FlowControlToken() { return &flow_control_; }
+   private:
+    api::FlowControlToken flow_control_;
   };
 
   static Primary::VirtualSecondaryConfig addDefaultSecondary(Config& config, const TemporaryDirectory& temp_dir,

--- a/tests/uptane_vector_tests.cc
+++ b/tests/uptane_vector_tests.cc
@@ -129,7 +129,8 @@ TEST_P(UptaneVector, Test) {
 
   auto storage = INvStorage::newStorage(config.storage);
   auto http_client = std::make_shared<HttpWrapper>();
-  auto uptane_client = std_::make_unique<SotaUptaneClient>(config, storage, http_client, nullptr);
+  api::FlowControlToken flow_control;
+  auto uptane_client = std_::make_unique<SotaUptaneClient>(config, storage, http_client, nullptr, &flow_control);
   auto ecu_serial = uptane_client->provisioner_.PrimaryEcuSerial();
   auto hw_id = uptane_client->provisioner_.PrimaryHardwareIdentifier();
   EXPECT_EQ(ecu_serial.ToString(), config.provision.primary_ecu_serial);
@@ -198,7 +199,7 @@ TEST_P(UptaneVector, Test) {
 
 std::vector<string> GetVectors() {
   HttpClient http_client;
-  const Json::Value json_vectors = http_client.get(address, HttpInterface::kNoLimit).getJson();
+  const Json::Value json_vectors = http_client.get(address, HttpInterface::kNoLimit, nullptr).getJson();
   std::vector<string> vectors;
   for (Json::ValueConstIterator it = json_vectors.begin(); it != json_vectors.end(); it++) {
     vectors.emplace_back((*it).asString());


### PR DESCRIPTION
Push the FlowControlToken (which allows aborts of in-progress operations in the CommandQueue) further down the call stack.

This is one part of allowing offline and online updates to co-exist: if an online update is in progress over a very slow GSM modem, then it should be possible to plug in a USB stick, cancel the in-progress update and start installing the new one inside a few seconds.