### PR TITLE
Various tidy-ups

### DIFF
--- a/src/libaktualizr/package_manager/packagemanagerfake.cc
+++ b/src/libaktualizr/package_manager/packagemanagerfake.cc
@@ -35,10 +35,10 @@ data::InstallationResult PackageManagerFake::install(const Uptane::Target& targe
   if (fiu_fail("fake_package_install") != 0) {
     std::string failure_cause = fault_injection_last_info();
     if (failure_cause.empty()) {
-      return data::InstallationResult(data::ResultCode::Numeric::kInstallFailed, "");
+      return {data::ResultCode::Numeric::kInstallFailed, ""};
     }
     LOG_DEBUG << "Causing installation failure with message: " << failure_cause;
-    return data::InstallationResult(data::ResultCode(data::ResultCode::Numeric::kInstallFailed, failure_cause), "");
+    return {data::ResultCode(data::ResultCode::Numeric::kInstallFailed, failure_cause), ""};
   }
 
   if (config.fake_need_reboot) {
@@ -46,10 +46,10 @@ data::InstallationResult PackageManagerFake::install(const Uptane::Target& targe
     if (bootloader_ != nullptr) {
       bootloader_->rebootFlagSet();
     }
-    return data::InstallationResult(data::ResultCode::Numeric::kNeedCompletion, "Application successful, need reboot");
+    return {data::ResultCode::Numeric::kNeedCompletion, "Application successful, need reboot"};
   }
 
-  return data::InstallationResult(data::ResultCode::Numeric::kOk, "Installing package was successful");
+  return {data::ResultCode::Numeric::kOk, "Installing package was successful"};
 }
 
 void PackageManagerFake::completeInstall() const {

--- a/src/libaktualizr/package_manager/packagemanagerinterface.cc
+++ b/src/libaktualizr/package_manager/packagemanagerinterface.cc
@@ -83,7 +83,7 @@ static int ProgressHandler(void* clientp, curl_off_t dltotal, curl_off_t dlnow, 
       ds->time_lastreport = now;
     }
   }
-  if (ds->token != nullptr && !ds->token->canContinue(false)) {
+  if (ds->token != nullptr && ds->token->hasAborted()) {
     return 1;
   }
   return 0;

--- a/src/libaktualizr/primary/provisioner.cc
+++ b/src/libaktualizr/primary/provisioner.cc
@@ -11,16 +11,15 @@
 #include "logging/logging.h"
 
 using std::map;
-using std::move;
 using std::shared_ptr;
 
 Provisioner::Provisioner(const ProvisionConfig& config, shared_ptr<INvStorage> storage,
                          shared_ptr<HttpInterface> http_client, shared_ptr<KeyManager> key_manager,
                          const map<Uptane::EcuSerial, shared_ptr<SecondaryInterface>>& secondaries)
     : config_(config),
-      storage_(move(storage)),
-      http_client_(move(http_client)),
-      key_manager_(move(key_manager)),
+      storage_(std::move(storage)),
+      http_client_(std::move(http_client)),
+      key_manager_(std::move(key_manager)),
       secondaries_(secondaries) {}
 
 void Provisioner::SecondariesWereChanged() { current_state_ = State::kUnknown; }

--- a/src/libaktualizr/uptane/CMakeLists.txt
+++ b/src/libaktualizr/uptane/CMakeLists.txt
@@ -28,10 +28,12 @@ add_library(uptane OBJECT ${SOURCES})
 add_aktualizr_test(NAME tuf SOURCES tuf_test.cc PROJECT_WORKING_DIRECTORY)
 
 if(BUILD_OSTREE AND SOTA_PACKED_CREDENTIALS)
-    add_aktualizr_test(NAME uptane_ci SOURCES uptane_ci_test.cc PROJECT_WORKING_DIRECTORY
-                        ARGS ${SOTA_PACKED_CREDENTIALS} ${PROJECT_BINARY_DIR}/ostree_repo)
+    add_aktualizr_test(NAME uptane_ci SOURCES uptane_ci_test.cc
+                       PROJECT_WORKING_DIRECTORY
+                       LIBRARIES virtual_secondary
+                       ARGS ${SOTA_PACKED_CREDENTIALS} ${PROJECT_BINARY_DIR}/ostree_repo)
     set_tests_properties(test_uptane_ci PROPERTIES LABELS "credentials")
-    target_link_libraries(t_uptane_ci virtual_secondary)
+
 else(BUILD_OSTREE AND SOTA_PACKED_CREDENTIALS)
     list(APPEND TEST_SOURCES uptane_ci_test.cc)
 endif(BUILD_OSTREE AND SOTA_PACKED_CREDENTIALS)

--- a/src/libaktualizr/utilities/types.cc
+++ b/src/libaktualizr/utilities/types.cc
@@ -112,6 +112,7 @@ const std::map<data::ResultCode::Numeric, const char *> data::ResultCode::string
     {ResultCode::Numeric::kGeneralError, "GENERAL_ERROR"},
     {ResultCode::Numeric::kNeedCompletion, "NEED_COMPLETION"},
     {ResultCode::Numeric::kCustomError, "CUSTOM_ERROR"},
+    {ResultCode::Numeric::kOperationCancelled, "OPERATION_CANCELLED"},
     {ResultCode::Numeric::kUnknown, "UNKNOWN"},
 };
 


### PR DESCRIPTION
This is a collection of small fixes that have accumulated on the Toradex fork over time. A couple of themes are:

- Qualify calls to std::move.
- Avoid repeating the return type.

Both of these generate clang diagnostics, so I think it is better to fix them.