### PR TITLE
Fetch garage-sign from a new location

### DIFF
--- a/scripts/get-garage-sign.py
+++ b/scripts/get-garage-sign.py
@@ -12,7 +12,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 
-aws_bucket_url = 'https://tuf-cli-releases.ota.here.com/'
+aws_bucket_url = 'https://garage-sign.s3.eu-west-1.amazonaws.com/'
 
 
 def main():


### PR DESCRIPTION
The old URL was owned by HERE and has gone with the discontinuation of HERE OTA Connect. Copy the latest releases to a AWS bucket and use that instead.

Fix for https://github.com/uptane/meta-updater/issues/102