### PR TITLE
Tidy up RepositoryType

### DIFF
--- a/src/aktualizr_secondary/aktualizr_secondary.cc
+++ b/src/aktualizr_secondary/aktualizr_secondary.cc
@@ -324,7 +324,6 @@ AktualizrSecondary::ReturnCode AktualizrSecondary::getRootVerHdlr(Asn1Message& i
     repo_type = Uptane::RepositoryType::Image();
   } else {
     LOG_WARNING << "Received Root version request with invalid repo type: " << rv->repotype;
-    repo_type = Uptane::RepositoryType(-1);
   }
 
   int32_t root_version = -1;
@@ -350,7 +349,6 @@ AktualizrSecondary::ReturnCode AktualizrSecondary::putRootHdlr(Asn1Message& in_m
   } else if (pr->repotype == AKRepoType_image) {
     repo_type = Uptane::RepositoryType::Image();
   } else {
-    repo_type = Uptane::RepositoryType(-1);
   }
 
   const std::string json = ToString(pr->json);

--- a/src/libaktualizr/primary/sotauptaneclient.cc
+++ b/src/libaktualizr/primary/sotauptaneclient.cc
@@ -8,6 +8,7 @@
 #include "crypto/crypto.h"
 #include "crypto/keymanager.h"
 #include "libaktualizr/campaign.h"
+#include "libaktualizr/types.h"
 #include "logging/logging.h"
 #include "provisioner.h"
 #include "uptane/exceptions.h"
@@ -993,13 +994,13 @@ result::UpdateStatus SotaUptaneClient::checkUpdatesOffline(const std::vector<Upt
     const auto it = std::find_if(director_targets.cbegin(), director_targets.cend(), target_comp);
     if (it == director_targets.cend()) {
       LOG_ERROR << "No matching target in Director Targets metadata for " << target;
-      throw Uptane::Exception(Uptane::RepositoryType::DIRECTOR, "No matching target in Director Targets metadata");
+      throw Uptane::Exception(Uptane::RepositoryType::Director(), "No matching target in Director Targets metadata");
     }
 
     const auto image_target = findTargetInDelegationTree(target, true);
     if (image_target == nullptr) {
       LOG_ERROR << "No matching target in Image repo Targets metadata for " << target;
-      throw Uptane::Exception(Uptane::RepositoryType::IMAGE, "No matching target in Director Targets metadata");
+      throw Uptane::Exception(Uptane::RepositoryType::Director(), "No matching target in Director Targets metadata");
     }
   }
 

--- a/src/libaktualizr/storage/fsstorage_read.cc
+++ b/src/libaktualizr/storage/fsstorage_read.cc
@@ -109,24 +109,18 @@ bool FSStorageRead::loadTlsPkey(std::string* pkey) const { return loadTlsCommon(
 
 bool FSStorageRead::loadRoot(std::string* data, Uptane::RepositoryType repo, Uptane::Version version) const {
   boost::filesystem::path metafile;
-  switch (repo) {
-    case (Uptane::RepositoryType::Director()):
-      if (version.version() < 0) {
-        version = latest_director_root;
-      }
-      metafile =
-          config_.uptane_metadata_path.get(config_.path) / "director" / version.RoleFileName(Uptane::Role::Root());
-      break;
-
-    case (Uptane::RepositoryType::Image()):
-      if (version.version() < 0) {
-        version = latest_director_root;
-      }
-      metafile = config_.uptane_metadata_path.get(config_.path) / "repo" / version.RoleFileName(Uptane::Role::Root());
-      break;
-
-    default:
-      return false;
+  if (repo == Uptane::RepositoryType::Director()) {
+    if (version.version() < 0) {
+      version = latest_director_root;
+    }
+    metafile = config_.uptane_metadata_path.get(config_.path) / "director" / version.RoleFileName(Uptane::Role::Root());
+  } else if (repo == Uptane::RepositoryType::Image()) {
+    if (version.version() < 0) {
+      version = latest_image_root;
+    }
+    metafile = config_.uptane_metadata_path.get(config_.path) / "repo" / version.RoleFileName(Uptane::Role::Root());
+  } else {
+    return false;
   }
 
   if (version.version() < 0) {
@@ -145,17 +139,12 @@ bool FSStorageRead::loadRoot(std::string* data, Uptane::RepositoryType repo, Upt
 
 bool FSStorageRead::loadNonRoot(std::string* data, Uptane::RepositoryType repo, const Uptane::Role& role) const {
   boost::filesystem::path metafile;
-  switch (repo) {
-    case (Uptane::RepositoryType::Director()):
-      metafile = config_.uptane_metadata_path.get(config_.path) / "director" / Uptane::Version().RoleFileName(role);
-      break;
-
-    case (Uptane::RepositoryType::Image()):
-      metafile = config_.uptane_metadata_path.get(config_.path) / "repo" / Uptane::Version().RoleFileName(role);
-      break;
-
-    default:
-      return false;
+  if (repo == Uptane::RepositoryType::Director()) {
+    metafile = config_.uptane_metadata_path.get(config_.path) / "director" / Uptane::Version().RoleFileName(role);
+  } else if (repo == Uptane::RepositoryType::Image()) {
+    metafile = config_.uptane_metadata_path.get(config_.path) / "repo" / Uptane::Version().RoleFileName(role);
+  } else {
+    return false;
   }
 
   if (!boost::filesystem::exists(metafile)) {
@@ -319,15 +308,12 @@ void FSStorageRead::clearTlsCreds() {
 
 void FSStorageRead::clearNonRootMeta(Uptane::RepositoryType repo) {
   boost::filesystem::path meta_path;
-  switch (repo) {
-    case Uptane::RepositoryType::Image():
-      meta_path = config_.uptane_metadata_path.get(config_.path) / "repo";
-      break;
-    case Uptane::RepositoryType::Director():
-      meta_path = config_.uptane_metadata_path.get(config_.path) / "director";
-      break;
-    default:
-      return;
+  if (repo == Uptane::RepositoryType::Image()) {
+    meta_path = config_.uptane_metadata_path.get(config_.path) / "repo";
+  } else if (repo == Uptane::RepositoryType::Director()) {
+    meta_path = config_.uptane_metadata_path.get(config_.path) / "director";
+  } else {
+    return;
   }
 
   boost::filesystem::directory_iterator it{meta_path};

--- a/src/libaktualizr/storage/sqlstorage_test.cc
+++ b/src/libaktualizr/storage/sqlstorage_test.cc
@@ -449,7 +449,7 @@ TEST(sqlstorage, migrate_root_works) {
   std::string raw_director_root;
   storage.loadRoot(&raw_director_root, Uptane::RepositoryType::Director(), Uptane::Version());
   Uptane::DirectorRepository director;
-  EXPECT_NO_THROW(director.initRoot(Uptane::RepositoryType(Uptane::RepositoryType::DIRECTOR), raw_director_root));
+  EXPECT_NO_THROW(director.initRoot(Uptane::RepositoryType::Director(), raw_director_root));
 
   std::string raw_director_targets;
   storage.loadNonRoot(&raw_director_targets, Uptane::RepositoryType::Director(), Uptane::Role::Targets());
@@ -460,7 +460,7 @@ TEST(sqlstorage, migrate_root_works) {
   std::string raw_image_root;
   storage.loadRoot(&raw_image_root, Uptane::RepositoryType::Image(), Uptane::Version());
   Uptane::ImageRepository imagerepository;
-  EXPECT_NO_THROW(imagerepository.initRoot(Uptane::RepositoryType(Uptane::RepositoryType::IMAGE), raw_image_root));
+  EXPECT_NO_THROW(imagerepository.initRoot(Uptane::RepositoryType::Image(), raw_image_root));
 
   // Check that the roots are different and haven't been swapped
   EXPECT_NE(raw_director_root, raw_image_root);

--- a/src/libaktualizr/uptane/director_test.cc
+++ b/src/libaktualizr/uptane/director_test.cc
@@ -20,7 +20,7 @@ TEST(Director, EmptyTargets) {
   uptane_gen.run({"generate", "--path", meta_dir.PathString(), "--correlationid", "cid1"});
 
   DirectorRepository director;
-  EXPECT_NO_THROW(director.initRoot(Uptane::RepositoryType(Uptane::RepositoryType::DIRECTOR),
+  EXPECT_NO_THROW(director.initRoot(Uptane::RepositoryType::Director(),
                                     Utils::readFile(meta_dir.Path() / "repo/director/root.json")));
 
   EXPECT_NO_THROW(director.verifyTargets(Utils::readFile(meta_dir.Path() / "repo/director/targets.json")));

--- a/src/libaktualizr/uptane/directorrepository.cc
+++ b/src/libaktualizr/uptane/directorrepository.cc
@@ -16,7 +16,7 @@ void DirectorRepository::resetMeta() {
 
 void DirectorRepository::checkTargetsExpired() {
   if (latest_targets.isExpired(TimeStamp::Now())) {
-    throw Uptane::ExpiredMetadata(type.ToString(), Role::TARGETS);
+    throw Uptane::ExpiredMetadata(type, Role::TARGETS);
   }
 }
 
@@ -24,7 +24,7 @@ void DirectorRepository::targetsSanityCheck() {
   //  5.4.4.6.6. If checking Targets metadata from the Director repository,
   //  verify that there are no delegations.
   if (!latest_targets.delegated_role_names_.empty()) {
-    throw Uptane::InvalidMetadata(type.ToString(), Role::TARGETS, "Found unexpected delegation.");
+    throw Uptane::InvalidMetadata(type, Role::TARGETS, "Found unexpected delegation.");
   }
   //  5.4.4.6.7. If checking Targets metadata from the Director repository,
   //  check that no ECU identifier is represented more than once.
@@ -35,7 +35,7 @@ void DirectorRepository::targetsSanityCheck() {
         ecu_ids.insert(ecu.first);
       } else {
         LOG_ERROR << "ECU " << ecu.first << " appears twice in Director's Targets";
-        throw Uptane::InvalidMetadata(type.ToString(), Role::TARGETS, "Found repeated ECU ID.");
+        throw Uptane::InvalidMetadata(type, Role::TARGETS, "Found repeated ECU ID.");
       }
     }
   }
@@ -68,13 +68,13 @@ void DirectorRepository::checkMetaOffline(INvStorage& storage) {
   {
     std::string director_root;
     if (!storage.loadLatestRoot(&director_root, RepositoryType::Director())) {
-      throw Uptane::SecurityException(RepositoryType::DIRECTOR, "Could not load latest root");
+      throw Uptane::SecurityException(RepositoryType::Director(), "Could not load latest root");
     }
 
-    initRoot(RepositoryType(RepositoryType::DIRECTOR), director_root);
+    initRoot(RepositoryType(RepositoryType::Director()), director_root);
 
     if (rootExpired()) {
-      throw Uptane::ExpiredMetadata(RepositoryType::DIRECTOR, Role::ROOT);
+      throw Uptane::ExpiredMetadata(RepositoryType::Director(), Role::ROOT);
     }
   }
 
@@ -83,7 +83,7 @@ void DirectorRepository::checkMetaOffline(INvStorage& storage) {
     std::string director_targets;
 
     if (!storage.loadNonRoot(&director_targets, RepositoryType::Director(), Role::Targets())) {
-      throw Uptane::SecurityException(RepositoryType::DIRECTOR, "Could not load Targets role");
+      throw Uptane::SecurityException(RepositoryType::Director(), "Could not load Targets role");
     }
 
     verifyTargets(director_targets);
@@ -135,7 +135,7 @@ void DirectorRepository::updateMeta(INvStorage& storage, const IMetadataFetcher&
     // that case, the member variable targets is updated, but it isn't stored in
     // the database, which can cause some minor confusion.
     if (local_version > remote_version) {
-      throw Uptane::SecurityException(RepositoryType::DIRECTOR, "Rollback attempt");
+      throw Uptane::SecurityException(RepositoryType::Director(), "Rollback attempt");
     } else if (local_version < remote_version && !usePreviousTargets()) {
       storage.storeNonRoot(director_targets, RepositoryType::Director(), Role::Targets());
     }

--- a/src/libaktualizr/uptane/fetcher.cc
+++ b/src/libaktualizr/uptane/fetcher.cc
@@ -16,7 +16,7 @@ void Fetcher::fetchRole(std::string* result, int64_t maxsize, RepositoryType rep
     throw Uptane::LocallyAborted(repo);
   }
   if (!response.isOk()) {
-    throw Uptane::MetadataFetchFailure(repo.ToString(), role.ToString());
+    throw Uptane::MetadataFetchFailure(repo, role.ToString());
   }
   *result = response.body;
 }

--- a/src/libaktualizr/uptane/imagerepository.cc
+++ b/src/libaktualizr/uptane/imagerepository.cc
@@ -28,7 +28,7 @@ void ImageRepository::verifyTimestamp(const std::string& timestamp_raw) {
 
 void ImageRepository::checkTimestampExpired() {
   if (timestamp.isExpired(TimeStamp::Now())) {
-    throw Uptane::ExpiredMetadata(type.ToString(), Role::TIMESTAMP);
+    throw Uptane::ExpiredMetadata(type, Role::TIMESTAMP);
   }
 }
 
@@ -48,7 +48,7 @@ void ImageRepository::fetchSnapshot(INvStorage& storage, const IMetadataFetcher&
   verifySnapshot(image_snapshot, false);
 
   if (local_version > remote_version) {
-    throw Uptane::SecurityException(RepositoryType::IMAGE, "Rollback attempt");
+    throw Uptane::SecurityException(RepositoryType::Image(), "Rollback attempt");
   } else {
     storage.storeNonRoot(image_snapshot, RepositoryType::Image(), Role::Snapshot());
   }
@@ -64,7 +64,7 @@ void ImageRepository::verifySnapshot(const std::string& snapshot_raw, bool prefe
           if (!prefetch) {
             LOG_ERROR << "Hash verification for Snapshot metadata failed";
           }
-          throw Uptane::SecurityException(RepositoryType::IMAGE, "Snapshot metadata hash verification failed");
+          throw Uptane::SecurityException(RepositoryType::Image(), "Snapshot metadata hash verification failed");
         }
         hash_exists = true;
         break;
@@ -73,7 +73,7 @@ void ImageRepository::verifySnapshot(const std::string& snapshot_raw, bool prefe
           if (!prefetch) {
             LOG_ERROR << "Hash verification for Snapshot metadata failed";
           }
-          throw Uptane::SecurityException(RepositoryType::IMAGE, "Snapshot metadata hash verification failed");
+          throw Uptane::SecurityException(RepositoryType::Image(), "Snapshot metadata hash verification failed");
         }
         hash_exists = true;
         break;
@@ -84,7 +84,7 @@ void ImageRepository::verifySnapshot(const std::string& snapshot_raw, bool prefe
 
   if (!hash_exists) {
     LOG_ERROR << "No hash found for shapshot.json";
-    throw Uptane::SecurityException(RepositoryType::IMAGE, "Snapshot metadata hash verification failed");
+    throw Uptane::SecurityException(RepositoryType::Image(), "Snapshot metadata hash verification failed");
   }
 
   try {
@@ -96,13 +96,13 @@ void ImageRepository::verifySnapshot(const std::string& snapshot_raw, bool prefe
   }
 
   if (snapshot.version() != timestamp.snapshot_version()) {
-    throw Uptane::VersionMismatch(RepositoryType::IMAGE, Uptane::Role::SNAPSHOT);
+    throw Uptane::VersionMismatch(RepositoryType::Image(), Uptane::Role::SNAPSHOT);
   }
 }
 
 void ImageRepository::checkSnapshotExpired() {
   if (snapshot.isExpired(TimeStamp::Now())) {
-    throw Uptane::ExpiredMetadata(type.ToString(), Role::SNAPSHOT);
+    throw Uptane::ExpiredMetadata(type, Role::SNAPSHOT);
   }
 }
 
@@ -123,7 +123,7 @@ void ImageRepository::fetchTargets(INvStorage& storage, const IMetadataFetcher& 
   verifyTargets(image_targets, false);
 
   if (local_version > remote_version) {
-    throw Uptane::SecurityException(RepositoryType::IMAGE, "Rollback attempt");
+    throw Uptane::SecurityException(RepositoryType::Image(), "Rollback attempt");
   } else {
     storage.storeNonRoot(image_targets, RepositoryType::Image(), targets_role);
   }
@@ -143,7 +143,7 @@ void ImageRepository::verifyRoleHashes(const std::string& role_data, const Uptan
           if (!prefetch) {
             LOG_ERROR << "Hash verification for " << role << " metadata failed";
           }
-          throw Uptane::SecurityException(RepositoryType::IMAGE,
+          throw Uptane::SecurityException(RepositoryType::Image(),
                                           "Snapshot hash mismatch for " + role.ToString() + " metadata");
         }
         break;
@@ -152,7 +152,7 @@ void ImageRepository::verifyRoleHashes(const std::string& role_data, const Uptan
           if (!prefetch) {
             LOG_ERROR << "Hash verification for " << role << " metadata failed";
           }
-          throw Uptane::SecurityException(RepositoryType::IMAGE,
+          throw Uptane::SecurityException(RepositoryType::Image(),
                                           "Snapshot hash mismatch for " + role.ToString() + " metadata");
         }
         break;
@@ -178,7 +178,7 @@ void ImageRepository::verifyTargets(const std::string& targets_raw, bool prefetc
         Targets(RepositoryType::Image(), Uptane::Role::Targets(), targets_json, signer));
 
     if (targets->version() != snapshot.role_version(Uptane::Role::Targets())) {
-      throw Uptane::VersionMismatch(RepositoryType::IMAGE, Uptane::Role::TARGETS);
+      throw Uptane::VersionMismatch(RepositoryType::Image(), Uptane::Role::TARGETS);
     }
   } catch (const Exception& e) {
     if (!prefetch) {
@@ -210,7 +210,7 @@ std::shared_ptr<Uptane::Targets> ImageRepository::verifyDelegation(const std::st
 
 void ImageRepository::checkTargetsExpired() {
   if (targets->isExpired(TimeStamp::Now())) {
-    throw Uptane::ExpiredMetadata(type.ToString(), Role::TARGETS);
+    throw Uptane::ExpiredMetadata(type, Role::TARGETS);
   }
 }
 
@@ -239,7 +239,7 @@ void ImageRepository::updateMeta(INvStorage& storage, const IMetadataFetcher& fe
     verifyTimestamp(image_timestamp);
 
     if (local_version > remote_version) {
-      throw Uptane::SecurityException(RepositoryType::IMAGE, "Rollback attempt");
+      throw Uptane::SecurityException(RepositoryType::Image(), "Rollback attempt");
     } else if (local_version < remote_version || timestamp_stored_signature != timestamp.signature()) {
       // If local and remote versions are the same but their content actually differ then store/update the metadata in
       // DB We assume that the metadata contains just one signature, otherwise the comparison might not always work
@@ -315,13 +315,13 @@ void ImageRepository::checkMetaOffline(INvStorage& storage) {
   {
     std::string image_root;
     if (!storage.loadLatestRoot(&image_root, RepositoryType::Image())) {
-      throw Uptane::SecurityException(RepositoryType::IMAGE, "Could not load latest root");
+      throw Uptane::SecurityException(RepositoryType::Image(), "Could not load latest root");
     }
 
-    initRoot(RepositoryType(RepositoryType::IMAGE), image_root);
+    initRoot(RepositoryType::Image(), image_root);
 
     if (rootExpired()) {
-      throw Uptane::ExpiredMetadata(RepositoryType::IMAGE, Role::Root().ToString());
+      throw Uptane::ExpiredMetadata(RepositoryType::Image(), Role::Root().ToString());
     }
   }
 
@@ -329,7 +329,7 @@ void ImageRepository::checkMetaOffline(INvStorage& storage) {
   {
     std::string image_timestamp;
     if (!storage.loadNonRoot(&image_timestamp, RepositoryType::Image(), Role::Timestamp())) {
-      throw Uptane::SecurityException(RepositoryType::IMAGE, "Could not load Timestamp role");
+      throw Uptane::SecurityException(RepositoryType::Image(), "Could not load Timestamp role");
     }
 
     verifyTimestamp(image_timestamp);
@@ -342,7 +342,7 @@ void ImageRepository::checkMetaOffline(INvStorage& storage) {
     std::string image_snapshot;
 
     if (!storage.loadNonRoot(&image_snapshot, RepositoryType::Image(), Role::Snapshot())) {
-      throw Uptane::SecurityException(RepositoryType::IMAGE, "Could not load Snapshot role");
+      throw Uptane::SecurityException(RepositoryType::Image(), "Could not load Snapshot role");
     }
 
     verifySnapshot(image_snapshot, false);
@@ -355,7 +355,7 @@ void ImageRepository::checkMetaOffline(INvStorage& storage) {
     std::string image_targets;
     Role targets_role = Uptane::Role::Targets();
     if (!storage.loadNonRoot(&image_targets, RepositoryType::Image(), targets_role)) {
-      throw Uptane::SecurityException(RepositoryType::IMAGE, "Could not load Image role");
+      throw Uptane::SecurityException(RepositoryType::Image(), "Could not load Image role");
     }
 
     verifyTargets(image_targets, false);

--- a/src/libaktualizr/uptane/iterator.cc
+++ b/src/libaktualizr/uptane/iterator.cc
@@ -1,5 +1,6 @@
 #include "iterator.h"
 
+#include "libaktualizr/types.h"
 #include "storage/invstorage.h"
 #include "uptane/exceptions.h"
 
@@ -15,7 +16,7 @@ Targets getTrustedDelegation(const Role &delegate_role, const Targets &parent_ta
     auto version = extractVersionUntrusted(delegation_meta);
 
     if (version > version_in_snapshot) {
-      throw SecurityException("image", "Rollback attempt on delegated targets");
+      throw SecurityException(RepositoryType::Image(), "Rollback attempt on delegated targets");
     } else if (version < version_in_snapshot) {
       delegation_meta.clear();
       storage.deleteDelegation(delegate_role);
@@ -46,12 +47,12 @@ Targets getTrustedDelegation(const Role &delegate_role, const Targets &parent_ta
 
   auto delegation = ImageRepository::verifyDelegation(delegation_meta, delegate_role, parent_targets);
   if (delegation == nullptr) {
-    throw SecurityException("image", "Delegation verification failed");
+    throw SecurityException(RepositoryType::Image(), "Delegation verification failed");
   }
 
   if (delegation_remote) {
     if (delegation->version() != version_in_snapshot) {
-      throw VersionMismatch("image", delegate_role.ToString());
+      throw VersionMismatch(RepositoryType::Image(), delegate_role.ToString());
     }
     storage.storeDelegation(delegation_meta, delegate_role);
   }

--- a/src/libaktualizr/uptane/metawithkeys.cc
+++ b/src/libaktualizr/uptane/metawithkeys.cc
@@ -61,8 +61,6 @@ void Uptane::MetaWithKeys::ParseRole(const RepositoryType repo, const Json::Valu
 
 void Uptane::MetaWithKeys::UnpackSignedObject(const RepositoryType repo, const Role &role,
                                               const Json::Value &signed_object) {
-  const std::string repository = repo;
-
   const Uptane::Role type(signed_object["signed"]["_type"].asString());
   if (role.IsDelegation()) {
     if (type != Uptane::Role::Targets()) {
@@ -84,7 +82,7 @@ void Uptane::MetaWithKeys::UnpackSignedObject(const RepositoryType repo, const R
   for (auto sig = signatures.begin(); sig != signatures.end(); ++sig) {
     const std::string keyid = (*sig)["keyid"].asString();
     if (used_keyids.count(keyid) != 0) {
-      throw NonUniqueSignatures(repository, role.ToString());
+      throw NonUniqueSignatures(repo, role.ToString());
     }
     used_keyids.insert(keyid);
 
@@ -92,7 +90,7 @@ void Uptane::MetaWithKeys::UnpackSignedObject(const RepositoryType repo, const R
     std::transform(method.begin(), method.end(), method.begin(), ::tolower);
 
     if (method != "rsassa-pss" && method != "rsassa-pss-sha256" && method != "ed25519") {
-      throw SecurityException(repository, std::string("Unsupported sign method: ") + (*sig)["method"].asString());
+      throw SecurityException(repo, std::string("Unsupported sign method: ") + (*sig)["method"].asString());
     }
 
     if (keys_.count(keyid) == 0U) {
@@ -113,14 +111,14 @@ void Uptane::MetaWithKeys::UnpackSignedObject(const RepositoryType repo, const R
   }
   const int64_t threshold = thresholds_for_role_[role];
   if (threshold < kMinSignatures || kMaxSignatures < threshold) {
-    throw IllegalThreshold(repository, "Invalid signature threshold");
+    throw IllegalThreshold(repo, "Invalid signature threshold");
   }
   // One signature and it is bad: throw bad key ID.
   // Multiple signatures but not enough good ones to pass threshold: throw unmet threshold.
   if (signatures.size() == 1 && valid_signatures == 0) {
-    throw BadKeyId(repository);
+    throw BadKeyId(repo);
   }
   if (valid_signatures < threshold) {
-    throw UnmetThreshold(repository, role.ToString());
+    throw UnmetThreshold(repo, role.ToString());
   }
 }

--- a/src/libaktualizr/uptane/root.cc
+++ b/src/libaktualizr/uptane/root.cc
@@ -27,13 +27,11 @@ Root::Root(const RepositoryType repo, const Json::Value &json) : MetaWithKeys(js
 }
 
 void Uptane::Root::UnpackSignedObject(const RepositoryType repo, const Role &role, const Json::Value &signed_object) {
-  const std::string repository = repo;
-
   if (policy_ == Policy::kAcceptAll) {
     return;
   }
   if (policy_ == Policy::kRejectAll) {
-    throw SecurityException(repository, "Root policy is Policy::kRejectAll");
+    throw SecurityException(repo, "Root policy is Policy::kRejectAll");
   }
   assert(policy_ == Policy::kCheck);
 

--- a/src/libaktualizr/uptane/tuf.cc
+++ b/src/libaktualizr/uptane/tuf.cc
@@ -290,14 +290,14 @@ std::ostream &Uptane::operator<<(std::ostream &os, const Target &t) {
 void Uptane::BaseMeta::init(const Json::Value &json) {
   if (!json.isObject() || !json.isMember("signed")) {
     LOG_ERROR << "Failure during base metadata initialization from json";
-    throw Uptane::InvalidMetadata("", "", "invalid metadata json");
+    throw Uptane::InvalidMetadata("invalid metadata json");
   }
 
   version_ = json["signed"]["version"].asInt();
   try {
     expiry_ = TimeStamp(json["signed"]["expires"].asString());
   } catch (const TimeStamp::InvalidTimeStamp &exc) {
-    throw Uptane::InvalidMetadata("", "", "invalid timestamp");
+    throw Uptane::InvalidMetadata("invalid timestamp");
   }
   original_object_ = json;
 }
@@ -306,7 +306,7 @@ Uptane::BaseMeta::BaseMeta(const Json::Value &json) { init(json); }
 Uptane::BaseMeta::BaseMeta(RepositoryType repo, const Role &role, const Json::Value &json,
                            const std::shared_ptr<MetaWithKeys> &signer) {
   if (!json.isObject() || !json.isMember("signed")) {
-    throw Uptane::InvalidMetadata("", "", "invalid metadata json");
+    throw Uptane::InvalidMetadata("invalid metadata json");
   }
 
   signer->UnpackSignedObject(repo, role, json);
@@ -316,20 +316,20 @@ Uptane::BaseMeta::BaseMeta(RepositoryType repo, const Role &role, const Json::Va
 
 std::string Uptane::BaseMeta::signature() const {
   if (!original_object_.isMember("signatures")) {
-    throw Uptane::InvalidMetadata("", "", "invalid metadata json, missing signatures");
+    throw Uptane::InvalidMetadata("invalid metadata json, missing signatures");
   }
   if (!original_object_["signatures"].isArray()) {
-    throw Uptane::InvalidMetadata("", "", "invalid metadata json, signatures are not an array");
+    throw Uptane::InvalidMetadata("invalid metadata json, signatures are not an array");
   }
   const auto signs{original_object_["signatures"]};
   if (signs.empty()) {
-    throw Uptane::InvalidMetadata("", "", "invalid metadata json, no any signatures found");
+    throw Uptane::InvalidMetadata("invalid metadata json, no any signatures found");
   }
   if (signs.size() > 1) {
     LOG_WARNING << "Metadata contains more than one signature\n" << original_object_;
   }
   if (!signs[0].isMember("sig")) {
-    throw Uptane::InvalidMetadata("", "", "invalid metadata json, missing signature");
+    throw Uptane::InvalidMetadata("invalid metadata json, missing signature");
   }
 
   return signs[0]["sig"].asString();
@@ -337,7 +337,7 @@ std::string Uptane::BaseMeta::signature() const {
 
 void Uptane::Targets::init(const Json::Value &json) {
   if (!json.isObject() || json["signed"]["_type"] != "Targets") {
-    throw Uptane::InvalidMetadata("", "targets", "invalid targets.json");
+    throw Uptane::InvalidMetadata("invalid targets.json");
   }
 
   const Json::Value target_list = json["signed"]["targets"];
@@ -389,7 +389,7 @@ void Uptane::TimestampMeta::init(const Json::Value &json) {
   Json::Value meta_version = json["signed"]["meta"]["snapshot.json"]["version"];
   if (!json.isObject() || json["signed"]["_type"] != "Timestamp" || !hashes_list.isObject() ||
       !meta_size.isIntegral() || !meta_version.isIntegral()) {
-    throw Uptane::InvalidMetadata("", "timestamp", "invalid timestamp.json");
+    throw Uptane::InvalidMetadata("invalid timestamp.json");
   }
 
   for (auto it = hashes_list.begin(); it != hashes_list.end(); ++it) {
@@ -411,7 +411,7 @@ Uptane::TimestampMeta::TimestampMeta(RepositoryType repo, const Json::Value &jso
 void Uptane::Snapshot::init(const Json::Value &json) {
   Json::Value meta_list = json["signed"]["meta"];
   if (!json.isObject() || json["signed"]["_type"] != "Snapshot" || !meta_list.isObject()) {
-    throw Uptane::InvalidMetadata("", "snapshot", "invalid snapshot.json");
+    throw Uptane::InvalidMetadata("invalid snapshot.json");
   }
 
   for (auto it = meta_list.begin(); it != meta_list.end(); ++it) {
@@ -420,7 +420,7 @@ void Uptane::Snapshot::init(const Json::Value &json) {
     Json::Value meta_version = (*it)["version"];
 
     if (!meta_version.isIntegral()) {
-      throw Uptane::InvalidMetadata("", "snapshot", "invalid snapshot.json");
+      throw Uptane::InvalidMetadata("invalid snapshot.json");
     }
 
     auto role_name =

--- a/src/libaktualizr/uptane/tuf.h
+++ b/src/libaktualizr/uptane/tuf.h
@@ -21,33 +21,30 @@ class RepositoryType {
   enum class Type { kUnknown = -1, kImage = 0, kDirector = 1 };
 
  public:
-  static const std::string IMAGE;
-  static const std::string DIRECTOR;
-
   RepositoryType() = default;
-  static constexpr int Director() { return static_cast<int>(Type::kDirector); }
-  static constexpr int Image() { return static_cast<int>(Type::kImage); }
-  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-  RepositoryType(int type) { type_ = static_cast<RepositoryType::Type>(type); }
+  static constexpr RepositoryType Director() { return RepositoryType(Type::kDirector); }
+  static constexpr RepositoryType Image() { return RepositoryType(Type::kImage); }
+  explicit constexpr RepositoryType(Type type) : type_{type} {}
   explicit RepositoryType(const std::string &repo_type) {
-    if (repo_type == DIRECTOR) {
+    if (repo_type == "director") {
       type_ = RepositoryType::Type::kDirector;
-    } else if (repo_type == IMAGE) {
+    } else if (repo_type == "image") {
       type_ = RepositoryType::Type::kImage;
     } else {
       throw std::runtime_error(std::string("Incorrect repo type: ") + repo_type);
     }
   }
+
+  bool operator==(RepositoryType other) const { return type_ == other.type_; }
+  explicit constexpr operator int() const { return static_cast<int>(type_); }
   // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-  operator int() const { return static_cast<int>(type_); }
-  // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-  operator std::string() const { return ToString(); }
-  Type type_;
-  std::string ToString() const {
+  explicit operator std::string() const { return ToString(); }  // TODO: fix this!
+  Type type_{Type::kUnknown};
+  [[nodiscard]] std::string ToString() const {
     if (type_ == RepositoryType::Type::kDirector) {
-      return DIRECTOR;
+      return "director";
     } else if (type_ == RepositoryType::Type::kImage) {
-      return IMAGE;
+      return "image";
     } else {
       return "";
     }

--- a/src/libaktualizr/uptane/tuf_test.cc
+++ b/src/libaktualizr/uptane/tuf_test.cc
@@ -283,6 +283,17 @@ TEST(Target, HashMismatch) {
   EXPECT_FALSE(target2.MatchTarget(target1));
 }
 
+/* RepositoryType roundtrips via a string, and has the name we expect */
+TEST(RepositoryType, StringRoundTrip) {
+  auto d = Uptane::RepositoryType::Director();
+  EXPECT_EQ(Uptane::RepositoryType(d.ToString()), d);
+  EXPECT_EQ(d.ToString(), "director");
+
+  auto i = Uptane::RepositoryType::Image();
+  EXPECT_EQ(Uptane::RepositoryType(i.ToString()), i);
+  EXPECT_EQ(i.ToString(), "image");
+}
+
 #ifndef __NO_MAIN__
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/libaktualizr/uptane/uptanerepository.cc
+++ b/src/libaktualizr/uptane/uptanerepository.cc
@@ -10,9 +10,6 @@
 
 namespace Uptane {
 
-const std::string RepositoryType::DIRECTOR = "director";
-const std::string RepositoryType::IMAGE = "image";
-
 void RepositoryCommon::initRoot(RepositoryType repo_type, const std::string& root_raw) {
   try {
     root = Root(type, Utils::parseJSON(root_raw));        // initialization and format check
@@ -38,7 +35,7 @@ void RepositoryCommon::verifyRoot(const std::string& root_raw) {
     if (root.version() != prev_version + 1) {
       LOG_ERROR << "Version " << root.version() << " in Root metadata doesn't match the expected value "
                 << prev_version + 1;
-      throw Uptane::RootRotationError(type.ToString());
+      throw Uptane::RootRotationError(type);
     }
   } catch (const std::exception& e) {
     LOG_ERROR << "Signature verification for Root metadata failed: " << e.what();
@@ -84,7 +81,7 @@ void RepositoryCommon::updateRoot(INvStorage& storage, const IMetadataFetcher& f
   // lower than the expiration timestamp in the latest Root metadata file.
   // (Checks for a freeze attack.)
   if (rootExpired()) {
-    throw Uptane::ExpiredMetadata(repo_type.ToString(), Role::ROOT);
+    throw Uptane::ExpiredMetadata(repo_type, Role::ROOT);
   }
 }
 


### PR DESCRIPTION
RepositoryType was a weird mix of a proper class type, a string and an int. Tidy this up to use the RepositoryType class everwhere, and only convert to a std::string when needed.

This is a particularly nice improvement in the Uptane::Expection implementations, where we now have proper types that can be type checked.