### PR TITLE
Fix possible use-after-free on reference count and some minor CI changes

### DIFF
--- a/.github/workflows/update-docker.yml
+++ b/.github/workflows/update-docker.yml
@@ -1,10 +1,11 @@
 name: Aktualizr CI docker images update
 on:
   push:
-    branches: [ master ]
+    branches: [master]
 jobs:
   update-bionic:
     name: Update Ubuntu Bionic Image
+    if: github.repository == 'uptane/aktualizr'
     runs-on: ubuntu-latest
     env:
       DOCKER_TAG: docker.pkg.github.com/uptane/aktualizr/aktualizr-ci:bionic-master
@@ -21,6 +22,7 @@ jobs:
 
   update-ubuntu-focal:
     name: Update Ubuntu Focal Image
+    if: github.repository == 'uptane/aktualizr'
     runs-on: ubuntu-latest
     env:
       DOCKER_TAG: docker.pkg.github.com/uptane/aktualizr/aktualizr-ci:ubuntu-focal-master

--- a/scripts/get_version.sh
+++ b/scripts/get_version.sh
@@ -5,4 +5,8 @@ set -euo pipefail
 GIT=${1:-git}
 REPO=${2:-.}
 
-"$GIT" -C "$REPO" describe --long | tr -d '\n'
+if ! VERSION=$("$GIT" -C "$REPO" describe --long 2>/dev/null | tr -d '\n'); then
+    VERSION=$("$GIT" -C "$REPO" rev-parse --short HEAD | tr -d '\n')
+fi
+
+printf "%s" "$VERSION"


### PR DESCRIPTION
Hi there! I have several commits that I want to try to get feedback on and I'm slowly working them upstream, mainly about getting Aktualizr to build with newer dependencies mainly because Debian Bullseye is getting EOL'd quite soon (2026-08-31) and I'd like to have a working MacOS build with what's available on brew.

Thus this is the first commit that fixes a possible use-after-free that GCC 12+ (on Bookworm, brew) yells about.

The other major fixes I'm working with are related to Boost: a ton of stuff changed from Bullseye. Do you explicitly want to keep compatibility with the older releases? Are there plans to drop bullseye eventually so I can focus my efforts on just bringing the build up to the latest ones?

Thanks!