### PR TITLE
Revert "Set an upper bound of allowed root rotations to 1000."

### DIFF
--- a/src/libaktualizr/uptane/uptanerepository.cc
+++ b/src/libaktualizr/uptane/uptanerepository.cc
@@ -60,7 +60,7 @@ void RepositoryCommon::updateRoot(INvStorage& storage, const IMetadataFetcher& f
   }
 
   // 5.4.4.3.2. Update to the latest Root metadata file.
-  for (int version = rootVersion() + 1; version < kMaxRotations; ++version) {
+  for (int version = rootVersion() + 1;; ++version) {
     // 5.4.4.3.2.2. Try downloading a new version N+1 of the Root metadata file.
     std::string root_raw;
     try {

--- a/src/libaktualizr/uptane/uptanerepository.h
+++ b/src/libaktualizr/uptane/uptanerepository.h
@@ -47,8 +47,6 @@ class RepositoryCommon {
   void resetRoot();
   void updateRoot(INvStorage &storage, const IMetadataFetcher &fetcher, RepositoryType repo_type);
 
-  static const int64_t kMaxRotations = 1000;
-
   Root root{Root::Policy::kRejectAll};
   RepositoryType type;
 };


### PR DESCRIPTION
This reverts commit ff053f9820611c7a54ca5baadccef61d35445c4d.

The upper bound on the number of rotations provides no real protection against attacks and adds a constraint that will at some point affect users who frequently rotate their keys.
